### PR TITLE
erstatt N+1-spørringer med én batch-spørring i MaksimumRepository

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
@@ -129,6 +129,33 @@ class MaksimumRepository(private val dataSource: DataSource) {
 
 
 
+        private data class MeldekortRad(
+            val meldekortId: Long,
+            val timerArbeidet: Double,
+            val datoFra: LocalDate,
+            val datoTil: LocalDate,
+            val belop: Int,
+        )
+
+        private fun mapTilUtbetaling(
+            rad: MeldekortRad,
+            anmerkninger: AnnenReduksjon?,
+            dagsats: Int,
+            barnetillegg: Int,
+        ): UtbetalingMedMer = UtbetalingMedMer(
+            reduksjon = Reduksjon(
+                timerArbeidet = rad.timerArbeidet,
+                annenReduksjon = anmerkninger ?: AnnenReduksjon(0.0f, false, 0.0f),
+            ),
+            periode = Periode(
+                fraOgMedDato = rad.datoFra,
+                tilOgMedDato = rad.datoTil,
+            ),
+            belop = rad.belop,
+            dagsats = dagsats,
+            barnetillegg = barnetillegg,
+        )
+
         fun selectUtbetalingVedVedtakId(
             vedtakId: Int,
             connection: Connection,
@@ -144,14 +171,6 @@ class MaksimumRepository(private val dataSource: DataSource) {
                 preparedStatement.setDate(3, Date.valueOf(fraDato))
                 preparedStatement.setDate(4, Date.valueOf(tilDato))
 
-                data class MeldekortRad(
-                    val meldekortId: Long,
-                    val timerArbeidet: Double,
-                    val datoFra: LocalDate,
-                    val datoTil: LocalDate,
-                    val belop: Int,
-                )
-
                 val rader = preparedStatement.executeQuery().map { row ->
                     MeldekortRad(
                         meldekortId = row.getLong("meldekort_id"),
@@ -162,27 +181,9 @@ class MaksimumRepository(private val dataSource: DataSource) {
                     )
                 }.toList()
 
-                val anmerkningerPerMeldekort = selectAlleMeldekortAnmerkninger(
-                    rader.map { it.meldekortId },
-                    connection,
-                )
-                val ingenAnmerkninger = AnnenReduksjon(0.0f, false, 0.0f)
+                val anmerkningerPerMeldekort = selectAlleMeldekortAnmerkninger(rader.map { it.meldekortId }, connection)
 
-                rader.map { rad ->
-                    UtbetalingMedMer(
-                        reduksjon = Reduksjon(
-                            timerArbeidet = rad.timerArbeidet,
-                            annenReduksjon = anmerkningerPerMeldekort[rad.meldekortId] ?: ingenAnmerkninger,
-                        ),
-                        periode = Periode(
-                            fraOgMedDato = rad.datoFra,
-                            tilOgMedDato = rad.datoTil,
-                        ),
-                        belop = rad.belop,
-                        dagsats = dagsats,
-                        barnetillegg = barnetiTillegg,
-                    )
-                }
+                rader.map { rad -> mapTilUtbetaling(rad, anmerkningerPerMeldekort[rad.meldekortId], dagsats, barnetiTillegg) }
             }
         }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
@@ -17,21 +17,178 @@ import java.time.LocalDate
 import javax.sql.DataSource
 
 class MaksimumRepository(private val dataSource: DataSource) {
+    private val log = LoggerFactory.getLogger(this::class.java)
 
     fun hentMaksimumsløsning(
         fodselsnr: String,
         fraOgMedDato: LocalDate,
-        tilOgMedDato: LocalDate
+        tilOgMedDato: LocalDate,
     ): Maksimum =
         dataSource.connection.use { con ->
             selectVedtakMaksimum(fodselsnr, fraOgMedDato, tilOgMedDato, con)
         }
 
-    companion object {
-        private val log = LoggerFactory.getLogger(this::class.java)
+    private fun selectVedtakMaksimum(
+        fodselsnr: String,
+        fraOgMedDato: LocalDate,
+        tilOgMedDato: LocalDate,
+        connection: Connection,
+    ): Maksimum {
+        log.info("Henter maksimumvedtak for periode $fraOgMedDato - $tilOgMedDato.")
+        return connection.prepareStatement(selectMaksimumMedTidsbegrensning).use { preparedStatement ->
+            preparedStatement.setString(1, fodselsnr)
+            preparedStatement.setDate(2, Date.valueOf(fraOgMedDato))
+            preparedStatement.setDate(3, Date.valueOf(tilOgMedDato))
 
-        @Language("OracleSql")
-        private val selectMaksimumMedTidsbegrensning = """
+            val resultSet = preparedStatement.executeQuery()
+            var c = 0
+            val vedtak = resultSet.map { row ->
+                val vedtakId = row.getInt("vedtak_id")
+                log.info("Henter utbetalinger for vedtak $vedtakId. Iterasjon nr $c.")
+                val vedtakFakta = selectVedtakFakta(vedtakId, connection)
+                val utbetalinger = selectUtbetalingVedVedtakId(
+                    connection = connection,
+                    barnetiTillegg = vedtakFakta.barntill,
+                    dagsats = vedtakFakta.dagsmbt,
+                    fodselsnr = fodselsnr,
+                    vedtakId = vedtakId,
+                    fraDato = row.getDate("fra_dato").toLocalDate(),
+                    tilDato = fraDato(row.getDate("til_dato")) ?: tilOgMedDato,
+                )
+                val vedtaktypekode = row.getString("vedtaktypekode")
+                c++
+                Vedtak(
+                    vedtaksId = vedtakId.toString(),
+                    utbetaling = utbetalinger,
+                    dagsats = vedtakFakta.dagsfsam,
+                    status = row.getString("vedtakstatuskode"),
+                    saksnummer = row.getString("sak_id"),
+                    vedtaksdato = row.getString("fra_dato"),
+                    rettighetsType = row.getString("aktfasekode"),
+                    periode = Periode(
+                        fraOgMedDato = row.getDate("fra_dato").toLocalDate(),
+                        tilOgMedDato = fraDato(row.getDate("til_dato")),
+                    ),
+                    beregningsgrunnlag = selectBeregningsgrunnlag(vedtakId, connection),
+                    barnMedStonad = vedtakFakta.barnmston,
+                    vedtaksTypeKode = vedtaktypekode,
+                    vedtaksTypeNavn = VedtaksType.entries.find { it.kode == vedtaktypekode }?.navn
+                        ?: error("Ukjent verdi vedtaktypekode=$vedtaktypekode"),
+                )
+            }.toList()
+            Maksimum(vedtak)
+        }
+    }
+
+    private fun selectUtbetalingVedVedtakId(
+        vedtakId: Int,
+        connection: Connection,
+        barnetiTillegg: Int,
+        dagsats: Int,
+        fodselsnr: String,
+        fraDato: LocalDate,
+        tilDato: LocalDate,
+    ): List<UtbetalingMedMer> {
+        return connection.prepareStatement(selectTimerArbeidetIMeldekortPeriode).use { preparedStatement ->
+            preparedStatement.setInt(1, vedtakId)
+            preparedStatement.setString(2, fodselsnr)
+            preparedStatement.setDate(3, Date.valueOf(fraDato))
+            preparedStatement.setDate(4, Date.valueOf(tilDato))
+
+            val rader = preparedStatement.executeQuery().map { row ->
+                MeldekortRad(
+                    meldekortId = row.getLong("meldekort_id"),
+                    timerArbeidet = row.getFloat("timer_arbeidet").toDouble(),
+                    datoFra = row.getDate("DATO_FRA").toLocalDate(),
+                    datoTil = row.getDate("DATO_TIL").toLocalDate(),
+                    belop = row.getInt("belop"),
+                )
+            }.toList()
+
+            val anmerkningerPerMeldekort = selectAlleMeldekortAnmerkninger(rader.map { it.meldekortId }, connection)
+            rader.map { rad -> mapTilUtbetaling(rad, anmerkningerPerMeldekort[rad.meldekortId], dagsats, barnetiTillegg) }
+        }
+    }
+
+    private fun selectAlleMeldekortAnmerkninger(
+        meldekortIder: List<Long>,
+        connection: Connection,
+    ): Map<Long, AnnenReduksjon> {
+        if (meldekortIder.isEmpty()) return emptyMap()
+        val sql = selectAnmerkningerForMeldekortliste(meldekortIder)
+        return connection.createStatement().use { statement ->
+            statement.executeQuery(sql).map { row ->
+                row.getLong("objekt_id") to AnnenReduksjon(
+                    sykedager = row.getFloat("sykedager"),
+                    sentMeldekort = row.getFloat("for_sent") > 0,
+                    fraver = row.getFloat("fravar"),
+                )
+            }.toMap()
+        }
+    }
+
+    private fun selectBeregningsgrunnlag(vedtakId: Int, connection: Connection): Int {
+        log.info("Henter beregningsgrunnlag for vedtak $vedtakId.")
+        return connection.prepareStatement(hentBeregningsgrunnlag).use { preparedStatement ->
+            preparedStatement.setInt(1, vedtakId)
+            val resultSet = preparedStatement.executeQuery()
+            var beregningsgrunnlag: Int? = null
+            resultSet.map { row ->
+                if (row.getString("vedtakfaktakode") == "GRUNN") {
+                    beregningsgrunnlag = row.getInt("vedtakverdi")
+                }
+            }
+            beregningsgrunnlag ?: 0
+        }
+    }
+
+    private fun selectVedtakFakta(vedtakId: Int, connection: Connection): VedtakFakta {
+        return connection.prepareStatement(hentVedtakfakta).use { preparedStatement ->
+            preparedStatement.setInt(1, vedtakId)
+            val resultSet = preparedStatement.executeQuery()
+            val vedtakfakta = VedtakFakta(0, 0, 0, 0, 0)
+            resultSet.map { row ->
+                when (row.getString("vedtakfaktakode")) {
+                    "DAGSMBT" -> vedtakfakta.dagsmbt = row.getInt("vedtakverdi")
+                    "BARNTILL" -> vedtakfakta.barntill = row.getInt("vedtakverdi")
+                    "DAGS" -> vedtakfakta.dags = row.getInt("vedtakverdi")
+                    "BARNMSTON" -> vedtakfakta.barnmston = row.getInt("vedtakverdi")
+                    "DAGSFSAM" -> vedtakfakta.dagsfsam = row.getInt("vedtakverdi")
+                }
+            }
+            vedtakfakta
+        }
+    }
+
+    private data class MeldekortRad(
+        val meldekortId: Long,
+        val timerArbeidet: Double,
+        val datoFra: LocalDate,
+        val datoTil: LocalDate,
+        val belop: Int,
+    )
+
+    private fun mapTilUtbetaling(
+        rad: MeldekortRad,
+        anmerkninger: AnnenReduksjon?,
+        dagsats: Int,
+        barnetillegg: Int,
+    ): UtbetalingMedMer = UtbetalingMedMer(
+        reduksjon = Reduksjon(
+            timerArbeidet = rad.timerArbeidet,
+            annenReduksjon = anmerkninger ?: AnnenReduksjon(0.0f, false, 0.0f),
+        ),
+        periode = Periode(
+            fraOgMedDato = rad.datoFra,
+            tilOgMedDato = rad.datoTil,
+        ),
+        belop = rad.belop,
+        dagsats = dagsats,
+        barnetillegg = barnetillegg,
+    )
+
+    @Language("OracleSql")
+    private val selectMaksimumMedTidsbegrensning = """
         SELECT vedtak_id, til_dato, fra_dato, vedtaktypekode, vedtakstatuskode, sak_id, aktfasekode 
           FROM vedtak 
          WHERE person_id = 
@@ -47,24 +204,24 @@ class MaksimumRepository(private val dataSource: DataSource) {
            AND fra_dato <= ?
     """.trimIndent()
 
-        @Language("OracleSql")
-        private val hentBeregningsgrunnlag = """
+    @Language("OracleSql")
+    private val hentBeregningsgrunnlag = """
         SELECT vedtakfaktakode, vedtakverdi
-            FROM vedtakfakta 
-             WHERE vedtak_id = ? AND vedtakfaktakode IN ('GRUNN')
+          FROM vedtakfakta 
+         WHERE vedtak_id = ? AND vedtakfaktakode IN ('GRUNN')
     """.trimIndent()
 
-        @Language("OracleSql")
-        private val hentVedtakfakta = """
+    @Language("OracleSql")
+    private val hentVedtakfakta = """
         SELECT vedtakfaktakode, vedtakverdi
-            FROM vedtakfakta 
-             WHERE vedtak_id = ? AND vedtakfaktakode IN ('DAGSMBT', 'BARNTILL', 'DAGS', 'BARNMSTON', 'DAGSFSAM')
+          FROM vedtakfakta 
+         WHERE vedtak_id = ? AND vedtakfaktakode IN ('DAGSMBT', 'BARNTILL', 'DAGS', 'BARNMSTON', 'DAGSFSAM')
     """.trimIndent()
 
-        private fun selectAnmerkningerForMeldekortliste(meldekortIder: List<Long>): String {
-            // Oracle støtter ikke listeparametere i PreparedStatement, så meldekort-IDer interpoleres direkte.
-            val idListe = meldekortIder.joinToString(",")
-            return """
+    // Oracle støtter ikke listeparametere i PreparedStatement, så meldekort-IDer interpoleres direkte.
+    private fun selectAnmerkningerForMeldekortliste(meldekortIder: List<Long>): String {
+        val idListe = meldekortIder.joinToString(",")
+        return """
             SELECT objekt_id,
                    sum(CASE WHEN anmerkningkode = 'FSNN' THEN verdi ELSE 0 END) AS sykedager,
                    sum(CASE WHEN anmerkningkode = 'SENN' THEN verdi ELSE 0 END) AS for_sent,
@@ -74,12 +231,12 @@ class MaksimumRepository(private val dataSource: DataSource) {
                AND objekt_id IN ($idListe)
                AND anmerkningkode IN ('FSNN', 'SENN', 'FXNN')
              GROUP BY objekt_id
-            """.trimIndent()
-        }
+        """.trimIndent()
+    }
 
-        @Language("OracleSql")
-        //henter timer arbeidet for bruker x mellom y og z dato gruppert på meldekortperiode
-        private val selectTimerArbeidetIMeldekortPeriode = """
+    @Language("OracleSql")
+    // henter timer arbeidet for bruker x mellom y og z dato gruppert på meldekortperiode
+    private val selectTimerArbeidetIMeldekortPeriode = """
         SELECT 
             SUM(mkd.timer_arbeidet) AS timer_arbeidet,
             mkp.DATO_FRA,
@@ -107,172 +264,4 @@ class MaksimumRepository(private val dataSource: DataSource) {
             m.meldekort_id,
             p.belop
     """.trimIndent()
-
-        fun selectAlleMeldekortAnmerkninger(
-            meldekortIder: List<Long>,
-            connection: Connection
-        ): Map<Long, AnnenReduksjon> {
-            if (meldekortIder.isEmpty()) return emptyMap()
-            val sql = selectAnmerkningerForMeldekortliste(meldekortIder)
-            return connection.createStatement().use { statement ->
-                val resultSet = statement.executeQuery(sql)
-                resultSet.map { row ->
-                    row.getLong("objekt_id") to AnnenReduksjon(
-                        sykedager = row.getFloat("sykedager"),
-                        sentMeldekort = row.getFloat("for_sent") > 0,
-                        fraver = row.getFloat("fravar"),
-                    )
-                }.toMap()
-            }
-        }
-
-
-
-
-        private data class MeldekortRad(
-            val meldekortId: Long,
-            val timerArbeidet: Double,
-            val datoFra: LocalDate,
-            val datoTil: LocalDate,
-            val belop: Int,
-        )
-
-        private fun mapTilUtbetaling(
-            rad: MeldekortRad,
-            anmerkninger: AnnenReduksjon?,
-            dagsats: Int,
-            barnetillegg: Int,
-        ): UtbetalingMedMer = UtbetalingMedMer(
-            reduksjon = Reduksjon(
-                timerArbeidet = rad.timerArbeidet,
-                annenReduksjon = anmerkninger ?: AnnenReduksjon(0.0f, false, 0.0f),
-            ),
-            periode = Periode(
-                fraOgMedDato = rad.datoFra,
-                tilOgMedDato = rad.datoTil,
-            ),
-            belop = rad.belop,
-            dagsats = dagsats,
-            barnetillegg = barnetillegg,
-        )
-
-        fun selectUtbetalingVedVedtakId(
-            vedtakId: Int,
-            connection: Connection,
-            barnetiTillegg: Int,
-            dagsats: Int,
-            fodselsnr: String,
-            fraDato: LocalDate,
-            tilDato: LocalDate
-        ): List<UtbetalingMedMer> {
-            return connection.prepareStatement(selectTimerArbeidetIMeldekortPeriode).use { preparedStatement ->
-                preparedStatement.setInt(1, vedtakId)
-                preparedStatement.setString(2, fodselsnr)
-                preparedStatement.setDate(3, Date.valueOf(fraDato))
-                preparedStatement.setDate(4, Date.valueOf(tilDato))
-
-                val rader = preparedStatement.executeQuery().map { row ->
-                    MeldekortRad(
-                        meldekortId = row.getLong("meldekort_id"),
-                        timerArbeidet = row.getFloat("timer_arbeidet").toDouble(),
-                        datoFra = row.getDate("DATO_FRA").toLocalDate(),
-                        datoTil = row.getDate("DATO_TIL").toLocalDate(),
-                        belop = row.getInt("belop"),
-                    )
-                }.toList()
-
-                val anmerkningerPerMeldekort = selectAlleMeldekortAnmerkninger(rader.map { it.meldekortId }, connection)
-
-                rader.map { rad -> mapTilUtbetaling(rad, anmerkningerPerMeldekort[rad.meldekortId], dagsats, barnetiTillegg) }
-            }
-        }
-
-        fun selectBeregningsgrunnlag(vedtakId: Int, connection: Connection): Int {
-            log.info("Henter beregningsgrunnlag for vedtak $vedtakId.")
-            return connection.prepareStatement(hentBeregningsgrunnlag).use { preparedStatement ->
-                preparedStatement.setInt(1, vedtakId)
-                val resultSet = preparedStatement.executeQuery()
-                var beregningsgrunnlag: Int? = null
-                resultSet.map { row ->
-                    if (row.getString("vedtakfaktakode") == "GRUNN") {
-                        beregningsgrunnlag = row.getInt("vedtakverdi")
-                    }
-                }
-                return@use beregningsgrunnlag ?: 0
-            }
-        }
-
-        fun selectVedtakFakta(vedtakId: Int, connection: Connection): VedtakFakta {
-            return connection.prepareStatement(hentVedtakfakta).use { preparedStatement ->
-                preparedStatement.setInt(1, vedtakId)
-                val resultSet = preparedStatement.executeQuery()
-                val vedtakfakta = VedtakFakta(0, 0, 0, 0, 0)
-                resultSet.map { row ->
-                    when (row.getString("vedtakfaktakode")) {
-                        "DAGSMBT" -> vedtakfakta.dagsmbt = row.getInt("vedtakverdi")
-                        "BARNTILL" -> vedtakfakta.barntill = row.getInt("vedtakverdi")
-                        "DAGS" -> vedtakfakta.dags = row.getInt("vedtakverdi")
-                        "BARNMSTON" -> vedtakfakta.barnmston = row.getInt("vedtakverdi")
-                        "DAGSFSAM" -> vedtakfakta.dagsfsam = row.getInt("vedtakverdi")
-                    }
-                }
-                vedtakfakta
-            }
-        }
-
-        fun selectVedtakMaksimum(
-            fodselsnr: String, fraOgMedDato: LocalDate, tilOgMedDato: LocalDate, connection: Connection
-        ): Maksimum {
-            log.info("Henter maksimumvedtak for periode $fraOgMedDato - $tilOgMedDato.")
-            val maksimum = connection.prepareStatement(selectMaksimumMedTidsbegrensning).use { preparedStatement ->
-                preparedStatement.setString(1, fodselsnr)
-                preparedStatement.setDate(2, Date.valueOf(fraOgMedDato))
-                preparedStatement.setDate(3, Date.valueOf(tilOgMedDato))
-
-                val resultSet = preparedStatement.executeQuery()
-                var c = 0
-                val vedtak = resultSet.map { row ->
-                    val utbetalinger = mutableListOf<UtbetalingMedMer>()
-                    val vedtakId = row.getInt("vedtak_id")
-                    log.info("Henter utbetalinger for vedtak $vedtakId. Iterasjon nr $c.")
-                    val vedtakFakta = selectVedtakFakta(vedtakId, connection)
-                    utbetalinger.addAll(
-                        selectUtbetalingVedVedtakId(
-                            connection = connection,
-                            barnetiTillegg = vedtakFakta.barntill,
-                            dagsats = vedtakFakta.dagsmbt,
-                            fodselsnr = fodselsnr,
-                            vedtakId = row.getInt("vedtak_id"),
-                            fraDato = row.getDate("fra_dato").toLocalDate(),
-                            tilDato = fraDato(row.getDate("til_dato"))?:tilOgMedDato
-                        )
-                    )
-                    val vedtaktypekode = row.getString("vedtaktypekode")
-                    c++
-                    Vedtak(
-                        vedtaksId = vedtakId.toString(),
-                        utbetaling = utbetalinger,
-                        dagsats = vedtakFakta.dagsfsam,
-                        status = row.getString("vedtakstatuskode"),
-                        saksnummer = row.getString("sak_id"),
-                        vedtaksdato = row.getString("fra_dato"),
-                        rettighetsType = row.getString("aktfasekode"),
-                        periode = Periode(
-                            fraOgMedDato = row.getDate("fra_dato").toLocalDate(),
-                            tilOgMedDato = fraDato(row.getDate("til_dato"))
-                        ),
-                        beregningsgrunnlag = selectBeregningsgrunnlag(vedtakId, connection),
-                        barnMedStonad = vedtakFakta.barnmston,
-                        vedtaksTypeKode = vedtaktypekode,
-                        vedtaksTypeNavn = VedtaksType.entries.find { it.kode == vedtaktypekode }?.navn
-                            ?: error("Ukjent verdi vedtaktypekode=$vedtaktypekode")
-                    )
-                }.toList()
-                Maksimum(vedtak)
-            }
-            return maksimum
-        }
-
-    }
-
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
@@ -61,17 +61,21 @@ class MaksimumRepository(private val dataSource: DataSource) {
              WHERE vedtak_id = ? AND vedtakfaktakode IN ('DAGSMBT', 'BARNTILL', 'DAGS', 'BARNMSTON', 'DAGSFSAM')
     """.trimIndent()
 
-        @Language("OracleSql")
-        private val selectAnmerkningerMeldekort = """
-        SELECT sum(CASE WHEN anmerkningkode = 'FSNN' THEN verdi ELSE 0 END) AS sykedager,
-               sum(CASE WHEN anmerkningkode = 'SENN' THEN verdi ELSE 0 END) AS for_sent,
-               sum(CASE WHEN anmerkningkode = 'FXNN' THEN verdi ELSE 0 END) AS fravar
-          FROM anmerkning
-         WHERE tabellnavnalias = 'MKORT'
-           AND objekt_id       = ?
-           AND anmerkningkode IN ('FSNN', 'SENN', 'FXNN')
-    """.trimIndent()
-        //Syk=FSNN', fravære = 'FXNN' og for sent = 'SENN'
+        private fun selectAnmerkningerForMeldekortliste(meldekortIder: List<Long>): String {
+            // Oracle støtter ikke listeparametere i PreparedStatement, så meldekort-IDer interpoleres direkte.
+            val idListe = meldekortIder.joinToString(",")
+            return """
+            SELECT objekt_id,
+                   sum(CASE WHEN anmerkningkode = 'FSNN' THEN verdi ELSE 0 END) AS sykedager,
+                   sum(CASE WHEN anmerkningkode = 'SENN' THEN verdi ELSE 0 END) AS for_sent,
+                   sum(CASE WHEN anmerkningkode = 'FXNN' THEN verdi ELSE 0 END) AS fravar
+              FROM anmerkning
+             WHERE tabellnavnalias = 'MKORT'
+               AND objekt_id IN ($idListe)
+               AND anmerkningkode IN ('FSNN', 'SENN', 'FXNN')
+             GROUP BY objekt_id
+            """.trimIndent()
+        }
 
         @Language("OracleSql")
         //henter timer arbeidet for bruker x mellom y og z dato gruppert på meldekortperiode
@@ -104,18 +108,21 @@ class MaksimumRepository(private val dataSource: DataSource) {
             p.belop
     """.trimIndent()
 
-        fun selectMeldekortAnmerkninger(meldekortId: String, connection: Connection): AnnenReduksjon {
-            return connection.prepareStatement(selectAnmerkningerMeldekort).use { preparedStatement ->
-                preparedStatement.setString(1, meldekortId)
-                val resultSet = preparedStatement.executeQuery()
-
+        fun selectAlleMeldekortAnmerkninger(
+            meldekortIder: List<Long>,
+            connection: Connection
+        ): Map<Long, AnnenReduksjon> {
+            if (meldekortIder.isEmpty()) return emptyMap()
+            val sql = selectAnmerkningerForMeldekortliste(meldekortIder)
+            return connection.createStatement().use { statement ->
+                val resultSet = statement.executeQuery(sql)
                 resultSet.map { row ->
-                    AnnenReduksjon(
+                    row.getLong("objekt_id") to AnnenReduksjon(
                         sykedager = row.getFloat("sykedager"),
-                        sentMeldekort = row.getFloat("for_sent")>0,
-                        fraver = row.getFloat("fravar")
+                        sentMeldekort = row.getFloat("for_sent") > 0,
+                        fraver = row.getFloat("fravar"),
                     )
-                }.toList().firstOrNull() ?: AnnenReduksjon(0.0f, false, 0.0f)
+                }.toMap()
             }
         }
 
@@ -137,23 +144,45 @@ class MaksimumRepository(private val dataSource: DataSource) {
                 preparedStatement.setDate(3, Date.valueOf(fraDato))
                 preparedStatement.setDate(4, Date.valueOf(tilDato))
 
-                val resultSet = preparedStatement.executeQuery()
+                data class MeldekortRad(
+                    val meldekortId: Long,
+                    val timerArbeidet: Double,
+                    val datoFra: LocalDate,
+                    val datoTil: LocalDate,
+                    val belop: Int,
+                )
 
-                resultSet.map { row ->
-                    //hent andmerking for sent meldekort
-                    val meldekortId = row.getString("meldekort_id")
-                    UtbetalingMedMer(
-                        reduksjon = Reduksjon(
-                            timerArbeidet = row.getFloat("timer_arbeidet").toDouble(), annenReduksjon = selectMeldekortAnmerkninger(
-                                meldekortId,
-                                connection
-                            )
-                        ), periode = Periode(
-                            fraOgMedDato = row.getDate("DATO_FRA").toLocalDate(),
-                            tilOgMedDato = row.getDate("DATO_TIL").toLocalDate(),
-                        ), belop = row.getInt("belop"), dagsats = dagsats, barnetillegg = barnetiTillegg
+                val rader = preparedStatement.executeQuery().map { row ->
+                    MeldekortRad(
+                        meldekortId = row.getLong("meldekort_id"),
+                        timerArbeidet = row.getFloat("timer_arbeidet").toDouble(),
+                        datoFra = row.getDate("DATO_FRA").toLocalDate(),
+                        datoTil = row.getDate("DATO_TIL").toLocalDate(),
+                        belop = row.getInt("belop"),
                     )
                 }.toList()
+
+                val anmerkningerPerMeldekort = selectAlleMeldekortAnmerkninger(
+                    rader.map { it.meldekortId },
+                    connection,
+                )
+                val ingenAnmerkninger = AnnenReduksjon(0.0f, false, 0.0f)
+
+                rader.map { rad ->
+                    UtbetalingMedMer(
+                        reduksjon = Reduksjon(
+                            timerArbeidet = rad.timerArbeidet,
+                            annenReduksjon = anmerkningerPerMeldekort[rad.meldekortId] ?: ingenAnmerkninger,
+                        ),
+                        periode = Periode(
+                            fraOgMedDato = rad.datoFra,
+                            tilOgMedDato = rad.datoTil,
+                        ),
+                        belop = rad.belop,
+                        dagsats = dagsats,
+                        barnetillegg = barnetiTillegg,
+                    )
+                }
             }
         }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
@@ -16,7 +16,11 @@ import java.sql.Date
 import java.time.LocalDate
 import javax.sql.DataSource
 
-class MaksimumRepository(private val dataSource: DataSource) {
+class MaksimumRepository(
+    private val dataSource: DataSource,
+    // Oracle har en hard grense på 1000 elementer i IN-lister. Vi chunker for å holde oss under denne grensen.
+    private val chunkStørrelse: Int = 999,
+) {
     private val log = LoggerFactory.getLogger(this::class.java)
 
     fun hentMaksimumsløsning(
@@ -115,16 +119,18 @@ class MaksimumRepository(private val dataSource: DataSource) {
         connection: Connection,
     ): Map<Long, AnnenReduksjon> {
         if (meldekortIder.isEmpty()) return emptyMap()
-        val sql = selectAnmerkningerForMeldekortliste(meldekortIder)
-        return connection.createStatement().use { statement ->
-            statement.executeQuery(sql).map { row ->
-                row.getLong("objekt_id") to AnnenReduksjon(
-                    sykedager = row.getFloat("sykedager"),
-                    sentMeldekort = row.getFloat("for_sent") > 0,
-                    fraver = row.getFloat("fravar"),
-                )
-            }.toMap()
-        }
+        return meldekortIder.chunked(chunkStørrelse).flatMap { chunk ->
+            val sql = selectAnmerkningerForMeldekortliste(chunk)
+            connection.createStatement().use { statement ->
+                statement.executeQuery(sql).map { row ->
+                    row.getLong("objekt_id") to AnnenReduksjon(
+                        sykedager = row.getFloat("sykedager"),
+                        sentMeldekort = row.getFloat("for_sent") > 0,
+                        fraver = row.getFloat("fravar"),
+                    )
+                }
+            }
+        }.toMap()
     }
 
     private fun selectBeregningsgrunnlag(vedtakId: Int, connection: Connection): Int {

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepositoryChunkingTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepositoryChunkingTest.kt
@@ -1,0 +1,35 @@
+package no.nav.aap.arenaoppslag.database
+
+import no.nav.aap.arenaoppslag.modeller.Periode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MaksimumRepositoryChunkingTest : H2TestBase("flyway/maksimum") {
+
+    // chunk-størrelse 1 tvinger ett databasekall per meldekort-id — verifiserer at chunking og sammenslåing
+    // av resultater fungerer korrekt selv når lista splittes i mange små biter
+    private val repo = MaksimumRepository(h2, chunkStørrelse = 1)
+
+    private val fnrMedVedtak = "12345678901"
+    private val søkeperiodeFra = LocalDate.of(2023, 1, 1)
+    private val søkeperiodeTil = LocalDate.of(2023, 12, 31)
+
+    @Test
+    fun `chunking slår korrekt sammen anmerkninger fra flere chunks`() {
+        val utbetalinger = repo.hentMaksimumsløsning(fnrMedVedtak, søkeperiodeFra, søkeperiodeTil)
+            .vedtak.first().utbetaling
+
+        assertThat(utbetalinger).hasSize(2)
+
+        // meldekort 5001: FSNN=1 (sykedag)
+        val utbetaling1 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 2) }!!
+        assertThat(utbetaling1.reduksjon!!.annenReduksjon.sykedager).isEqualTo(1.0f)
+        assertThat(utbetaling1.reduksjon!!.annenReduksjon.sentMeldekort).isFalse()
+
+        // meldekort 5002: SENN=1 (for sent) og FXNN=2 (fravær)
+        val utbetaling2 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 16) }!!
+        assertThat(utbetaling2.reduksjon!!.annenReduksjon.sentMeldekort).isTrue()
+        assertThat(utbetaling2.reduksjon!!.annenReduksjon.fraver).isEqualTo(2.0f)
+    }
+}

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepositoryTest.kt
@@ -1,0 +1,100 @@
+package no.nav.aap.arenaoppslag.database
+
+import no.nav.aap.arenaoppslag.modeller.Periode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MaksimumRepositoryTest : H2TestBase("flyway/maksimum") {
+
+    private val repo = MaksimumRepository(h2)
+
+    // Person med ett gyldig vedtak, to meldekortperioder, posteringer og meldekortdata
+    private val fnrMedVedtak = "12345678901"
+
+    // Person uten vedtak
+    private val fnrUtenVedtak = "00000000000"
+
+    // Person med vedtak i 2020 — utenfor standardsøkeperioden 2023
+    private val fnrVedtakUtenforPeriode = "11111111111"
+
+    private val søkeperiodeFra = LocalDate.of(2023, 1, 1)
+    private val søkeperiodeTil = LocalDate.of(2023, 12, 31)
+
+    @Test
+    fun `returnerer tomt vedtakliste for person uten vedtak`() {
+        val resultat = repo.hentMaksimumsløsning(fnrUtenVedtak, søkeperiodeFra, søkeperiodeTil)
+
+        assertThat(resultat.vedtak).isEmpty()
+    }
+
+    @Test
+    fun `returnerer tomt vedtakliste når vedtak er utenfor søkeperioden`() {
+        val resultat = repo.hentMaksimumsløsning(fnrVedtakUtenforPeriode, søkeperiodeFra, søkeperiodeTil)
+
+        assertThat(resultat.vedtak).isEmpty()
+    }
+
+    @Test
+    fun `henter vedtak med korrekte feltverdier`() {
+        val resultat = repo.hentMaksimumsløsning(fnrMedVedtak, søkeperiodeFra, søkeperiodeTil)
+
+        assertThat(resultat.vedtak).hasSize(1)
+        val vedtak = resultat.vedtak.first()
+        assertThat(vedtak.vedtaksId).isEqualTo("90010")
+        assertThat(vedtak.status).isEqualTo("IVERK")
+        assertThat(vedtak.saksnummer).isEqualTo("9001")
+        assertThat(vedtak.dagsats).isEqualTo(520)
+        assertThat(vedtak.beregningsgrunnlag).isEqualTo(450000)
+        assertThat(vedtak.barnMedStonad).isEqualTo(2)
+        assertThat(vedtak.vedtaksTypeKode).isEqualTo("O")
+        assertThat(vedtak.periode).isEqualTo(Periode(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 12, 31)))
+    }
+
+    @Test
+    fun `henter utbetalinger med korrekt periode, beløp og vedtakfakta`() {
+        val utbetalinger = repo.hentMaksimumsløsning(fnrMedVedtak, søkeperiodeFra, søkeperiodeTil)
+            .vedtak.first().utbetaling
+
+        assertThat(utbetalinger).hasSize(2)
+
+        val utbetaling1 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 2) }!!
+        assertThat(utbetaling1.periode).isEqualTo(Periode(LocalDate.of(2023, 1, 2), LocalDate.of(2023, 1, 15)))
+        assertThat(utbetaling1.belop).isEqualTo(7700)
+        assertThat(utbetaling1.dagsats).isEqualTo(550)
+        assertThat(utbetaling1.barnetillegg).isEqualTo(30)
+    }
+
+    @Test
+    fun `henter timer arbeidet per meldekortperiode`() {
+        val utbetalinger = repo.hentMaksimumsløsning(fnrMedVedtak, søkeperiodeFra, søkeperiodeTil)
+            .vedtak.first().utbetaling
+
+        val utbetaling1 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 2) }!!
+        val utbetaling2 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 16) }!!
+
+        assertThat(utbetaling1.reduksjon!!.timerArbeidet).isEqualTo(5.0)
+        assertThat(utbetaling2.reduksjon!!.timerArbeidet).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `henter meldekortdata per utbetalingsperiode`() {
+        val utbetalinger = repo.hentMaksimumsløsning(fnrMedVedtak, søkeperiodeFra, søkeperiodeTil)
+            .vedtak.first().utbetaling
+
+        val utbetaling1 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 2) }!!
+        val utbetaling2 = utbetalinger.find { it.periode.fraOgMedDato == LocalDate.of(2023, 1, 16) }!!
+
+        // meldekort 5001: FSNN=1, ingen SENN/FXNN
+        val meldekortdata1 = utbetaling1.reduksjon!!.annenReduksjon
+        assertThat(meldekortdata1.sykedager).isEqualTo(1.0f)
+        assertThat(meldekortdata1.sentMeldekort).isFalse()
+        assertThat(meldekortdata1.fraver).isEqualTo(0.0f)
+
+        // meldekort 5002: SENN=1, FXNN=2, ingen FSNN
+        val meldekortdata2 = utbetaling2.reduksjon!!.annenReduksjon
+        assertThat(meldekortdata2.sykedager).isEqualTo(0.0f)
+        assertThat(meldekortdata2.sentMeldekort).isTrue()
+        assertThat(meldekortdata2.fraver).isEqualTo(2.0f)
+    }
+}

--- a/app/src/test/resources/flyway/maksimum/V2_1__insert_maksimum_testdata.sql
+++ b/app/src/test/resources/flyway/maksimum/V2_1__insert_maksimum_testdata.sql
@@ -1,0 +1,104 @@
+-- Testdata for MaksimumRepositoryTest
+-- Person med ett vedtak, to meldekortperioder med utbetalinger og meldekortdata
+
+-- Person med gyldig vedtak
+insert into PERSON(PERSON_ID, FODSELSNR, ETTERNAVN, FORNAVN)
+values (100, '12345678901', 'Testesen', 'Maksimum');
+
+-- Sak
+Insert into SAK (SAK_ID, SAKSKODE, REG_DATO, REG_USER, MOD_DATO, MOD_USER, TABELLNAVNALIAS, OBJEKT_ID, AAR,
+                 LOPENRSAK, DATO_AVSLUTTET, SAKSTATUSKODE, AETATENHET_ANSVARLIG, PARTISJON, ER_UTLAND)
+values (9001, 'AA', DATE '2023-01-01', 'TEST', DATE '2023-01-01', 'TEST', 'PERS', 100, 2023, 9001, null, 'INAKT',
+        '4402', null, 'N');
+
+-- Vedtak (gyldig: utfallkode=JA, rettighetkode=AAP, vedtaktypekode=O, vedtakstatuskode=IVERK)
+insert into VEDTAK (VEDTAK_ID, SAK_ID, VEDTAKSTATUSKODE, VEDTAKTYPEKODE, UTFALLKODE, RETTIGHETKODE,
+                    PERSON_ID, FRA_DATO, TIL_DATO, AETATENHET_BEHANDLER, LOPENRSAK, AAR, LOPENRVEDTAK,
+                    AKTFASEKODE, DATO_MOTTATT)
+values (90010, 9001, 'IVERK', 'O', 'JA', 'AAP', 100,
+        DATE '2023-01-01', DATE '2023-12-31', '4402', 9001, 2023, 1, 'IKKE', DATE '2023-01-01');
+
+-- VedtakFakta for vedtak 90010
+insert into VEDTAKFAKTA (VEDTAK_ID, VEDTAKFAKTAKODE, VEDTAKVERDI)
+values (90010, 'DAGSMBT', '550'),
+       (90010, 'BARNTILL', '30'),
+       (90010, 'DAGS', '520'),
+       (90010, 'BARNMSTON', '2'),
+       (90010, 'DAGSFSAM', '520'),
+       (90010, 'GRUNN', '450000');
+
+-- Meldekortperioder
+insert into MELDEKORTPERIODE (AAR, PERIODEKODE, UKENR_UKE1, UKENR_UKE2, DATO_FRA, DATO_TIL)
+values (2023, '01', 1, 2, DATE '2023-01-02', DATE '2023-01-15'),
+       (2023, '02', 3, 4, DATE '2023-01-16', DATE '2023-01-29');
+
+-- Meldekort 1 (periode 01/2023)
+insert into MELDEKORT (MELDEKORT_ID, PERSON_ID, AAR, PERIODEKODE, MKSKORTKODE, BEREGNINGSTATUSKODE)
+values (5001, 100, 2023, '01', 'E1', 'FERDI');
+
+-- Meldekort 2 (periode 02/2023)
+insert into MELDEKORT (MELDEKORT_ID, PERSON_ID, AAR, PERIODEKODE, MKSKORTKODE, BEREGNINGSTATUSKODE)
+values (5002, 100, 2023, '02', 'E1', 'FERDI');
+
+-- Meldekortdager for meldekort 5001: 3 + 2 = 5 timer arbeidet
+insert into MELDEKORTDAG (MELDEKORT_ID, UKENR, DAGNR, STATUS_ARBEIDSDAG, STATUS_KURS, STATUS_SYK, TIMER_ARBEIDET)
+values (5001, 1, 1, 'J', 'N', 'N', 3.0),
+       (5001, 1, 2, 'J', 'N', 'N', 2.0),
+       (5001, 1, 3, 'N', 'N', 'N', 0.0),
+       (5001, 1, 4, 'N', 'N', 'N', 0.0),
+       (5001, 1, 5, 'N', 'N', 'N', 0.0),
+       (5001, 2, 1, 'N', 'N', 'N', 0.0),
+       (5001, 2, 2, 'N', 'N', 'N', 0.0),
+       (5001, 2, 3, 'N', 'N', 'N', 0.0),
+       (5001, 2, 4, 'N', 'N', 'N', 0.0),
+       (5001, 2, 5, 'N', 'N', 'N', 0.0);
+
+-- Meldekortdager for meldekort 5002: 4 timer arbeidet
+insert into MELDEKORTDAG (MELDEKORT_ID, UKENR, DAGNR, STATUS_ARBEIDSDAG, STATUS_KURS, STATUS_SYK, TIMER_ARBEIDET)
+values (5002, 3, 1, 'J', 'N', 'N', 4.0),
+       (5002, 3, 2, 'N', 'N', 'N', 0.0),
+       (5002, 3, 3, 'N', 'N', 'N', 0.0),
+       (5002, 3, 4, 'N', 'N', 'N', 0.0),
+       (5002, 3, 5, 'N', 'N', 'N', 0.0),
+       (5002, 4, 1, 'N', 'N', 'N', 0.0),
+       (5002, 4, 2, 'N', 'N', 'N', 0.0),
+       (5002, 4, 3, 'N', 'N', 'N', 0.0),
+       (5002, 4, 4, 'N', 'N', 'N', 0.0),
+       (5002, 4, 5, 'N', 'N', 'N', 0.0);
+
+-- Posteringer knyttet til vedtak 90010 og meldekortene
+insert into POSTERING (POSTERING_ID, BELOP, BELOPKODE, DATO_PERIODE_FRA, DATO_PERIODE_TIL, DATO_POSTERT, AAR,
+                       PERSON_ID, POSTERINGTYPEKODE, TRANSAKSJONSKODE, DATO_GRUNNLAG, VEDTAK_ID, ARTKODE,
+                       KAPITTEL, POST, UNDERPOST, BRUKER_ID_SAKSBEHANDLER, AETATENHET_ANSVARLIG, MELDEKORT_ID)
+values (8001, 7700, 'AAP', DATE '2023-01-02', DATE '2023-01-15', DATE '2023-01-20', 2023, 100,
+        'ORD', 'AA00', DATE '2023-01-02', 90010, 'ART', '2900', '01', '001', 'TEST', '4402', 5001),
+       (8002, 6600, 'AAP', DATE '2023-01-16', DATE '2023-01-29', DATE '2023-02-03', 2023, 100,
+        'ORD', 'AA00', DATE '2023-01-16', 90010, 'ART', '2900', '01', '001', 'TEST', '4402', 5002);
+
+-- Meldekortdata for meldekort 5001: 1 sykedag (FSNN)
+insert into ANMERKNING (ANMERKNING_ID, ANMERKNINGKODE, TABELLNAVNALIAS, OBJEKT_ID, VEDTAK_ID, VERDI)
+values (7001, 'FSNN', 'MKORT', 5001, 90010, 1);
+
+-- Meldekortdata for meldekort 5002: for sent (SENN=1) og fravær (FXNN=2)
+insert into ANMERKNING (ANMERKNING_ID, ANMERKNINGKODE, TABELLNAVNALIAS, OBJEKT_ID, VEDTAK_ID, VERDI)
+values (7002, 'SENN', 'MKORT', 5002, 90010, 1),
+       (7003, 'FXNN', 'MKORT', 5002, 90010, 2);
+
+-- Person uten vedtak
+insert into PERSON(PERSON_ID, FODSELSNR, ETTERNAVN, FORNAVN)
+values (101, '00000000000', 'Vedtaksløs', 'Inga');
+
+-- Person med vedtak utenfor søkeperioden
+insert into PERSON(PERSON_ID, FODSELSNR, ETTERNAVN, FORNAVN)
+values (102, '11111111111', 'Utenfor', 'Periode');
+
+Insert into SAK (SAK_ID, SAKSKODE, REG_DATO, REG_USER, MOD_DATO, MOD_USER, TABELLNAVNALIAS, OBJEKT_ID, AAR,
+                 LOPENRSAK, DATO_AVSLUTTET, SAKSTATUSKODE, AETATENHET_ANSVARLIG, PARTISJON, ER_UTLAND)
+values (9002, 'AA', DATE '2020-01-01', 'TEST', DATE '2020-01-01', 'TEST', 'PERS', 102, 2020, 9002, null, 'INAKT',
+        '4402', null, 'N');
+
+insert into VEDTAK (VEDTAK_ID, SAK_ID, VEDTAKSTATUSKODE, VEDTAKTYPEKODE, UTFALLKODE, RETTIGHETKODE,
+                    PERSON_ID, FRA_DATO, TIL_DATO, AETATENHET_BEHANDLER, LOPENRSAK, AAR, LOPENRVEDTAK,
+                    AKTFASEKODE, DATO_MOTTATT)
+values (90020, 9002, 'IVERK', 'O', 'JA', 'AAP', 102,
+        DATE '2020-01-01', DATE '2020-12-31', '4402', 9002, 2020, 1, 'IKKE', DATE '2020-01-01');


### PR DESCRIPTION
Resolves #432

## Bakgrunn

`selectUtbetalingVedVedtakId` kalte `selectMeldekortAnmerkninger` én gang per
meldekort-rad i result setet. I produksjon resulterte dette i 1400+ sekvensielle
spørringer mot Oracle per kall.

## Løsning

Alle meldekort-IDer materialiseres til en liste før databasekallet. Deretter hentes
alle anmerkninger i én spørring med `objekt_id IN (id1, id2, ...)`, og resultatet
mappes tilbake per meldekort. Regresjonstester er lagt til i `MaksimumRepositoryTest`.

Oracle støtter ikke liste-parametere i `PreparedStatement`, så IDene interpoleres
direkte i SQL-strengen — samme mønster som `PersonRepository` bruker for fødselsnummer.
IDene er numeriske og kommer fra databasen (ikke brukerinput), så dette er trygt.

Vi grupperer på `objekt_id` fordi vi henter data for flere meldekort samtidig.
På denne måten kan vi telle antall av de ulike anmerkningene per meldekort.