### PR TITLE
Utvid detaljert sak-respons med vilkårsvurderinger og løpenr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,24 @@ Use `ArenaOppslagGateway` as the HTTP client wrapper in integration tests.
 - `"007"` — used as "unknown person" (does not exist in any test dataset).
 
 ---
+
+## Git workflow
+
+Before committing, always:
+
+1. Show the user a summary of the changes to be committed.
+2. Propose a commit message and wait for explicit approval before proceeding.
+3. Do not commit until the user has confirmed both the changes and the message.
+
+Before pushing, confirm with the user that the commit(s) are ready to be pushed.
+
+Before creating a pull request, always:
+
+1. Propose a PR title and description and present them to the user.
+2. Wait for explicit approval — including any requested edits — before creating it.
+
+---
+
 ## Patterns to follow and to avoid
 Follow the repository pattern. 
 Avoid creating the "god class" anti-pattern , for example when creating services. Instead, create a service that uses other services as building blocks to achieve a service that can create rich composite objects. 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -22,6 +22,7 @@ import no.nav.aap.arenaoppslag.database.PeriodeRepository
 import no.nav.aap.arenaoppslag.database.PersonRepository
 import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.database.TelleverkRepository
+import no.nav.aap.arenaoppslag.database.VedtakfaktaRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
 import no.nav.aap.arenaoppslag.plugins.MdcKeys
 import no.nav.aap.arenaoppslag.plugins.authentication
@@ -149,7 +150,8 @@ private fun skapHistorikkService(datasource: DataSource): HistorikkService {
 private fun skapSakervice(datasource: DataSource): SakOgVedtakService {
     val vedtakRepository = VedtakRepository(datasource)
     val sakRepository = SakRepository(datasource)
-    return SakOgVedtakService(sakRepository, vedtakRepository)
+    val vedtakfaktaRepository = VedtakfaktaRepository(datasource)
+    return SakOgVedtakService(sakRepository, vedtakRepository, vedtakfaktaRepository)
 }
 
 private fun skapTelleverkService(datasource: DataSource): TelleverkService {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -24,6 +24,7 @@ import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.database.TelleverkRepository
 import no.nav.aap.arenaoppslag.database.VedtakfaktaRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
+import no.nav.aap.arenaoppslag.database.VilkårsvurderingRepository
 import no.nav.aap.arenaoppslag.plugins.MdcKeys
 import no.nav.aap.arenaoppslag.plugins.authentication
 import no.nav.aap.arenaoppslag.plugins.bruker
@@ -151,7 +152,8 @@ private fun skapSakervice(datasource: DataSource): SakOgVedtakService {
     val vedtakRepository = VedtakRepository(datasource)
     val sakRepository = SakRepository(datasource)
     val vedtakfaktaRepository = VedtakfaktaRepository(datasource)
-    return SakOgVedtakService(sakRepository, vedtakRepository, vedtakfaktaRepository)
+    val vilkårsvurderingRepository = VilkårsvurderingRepository(datasource)
+    return SakOgVedtakService(sakRepository, vedtakRepository, vedtakfaktaRepository, vilkårsvurderingRepository)
 }
 
 private fun skapTelleverkService(datasource: DataSource): TelleverkService {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
@@ -2,17 +2,23 @@ package no.nav.aap.arenaoppslag
 
 import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
+import no.nav.aap.arenaoppslag.database.VedtakfaktaRepository
 import no.nav.aap.arenaoppslag.modeller.ArenaSakMedVedtak
 import no.nav.aap.arenaoppslag.modeller.toArenaSakMedVedtak
 
 class SakOgVedtakService(
     private val sakRepository: SakRepository,
-    private val vedtakRepository: VedtakRepository
+    private val vedtakRepository: VedtakRepository,
+    private val vedtakfaktaRepository: VedtakfaktaRepository,
 ) {
     fun hentSakMedVedtak(saksId: Int): ArenaSakMedVedtak? {
-        val sak = sakRepository.hentSak(saksId)
-        val vedtakForSak = vedtakRepository.hentVedtakMedFaktaForSak(saksId)
+        val sak = sakRepository.hentSak(saksId) ?: return null
 
-        return sak?.toArenaSakMedVedtak(vedtakForSak)
+        val vedtak = vedtakRepository.hentVedtakForSak(saksId)
+        val faktaPerVedtak = vedtakfaktaRepository.hentForVedtakIder(vedtak.map { it.vedtakId })
+
+        val vedtakMedFakta = vedtak.map { it.medFakta(faktaPerVedtak[it.vedtakId] ?: emptyList()) }
+
+        return sak.toArenaSakMedVedtak(vedtakMedFakta)
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
@@ -3,6 +3,7 @@ package no.nav.aap.arenaoppslag
 import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
 import no.nav.aap.arenaoppslag.database.VedtakfaktaRepository
+import no.nav.aap.arenaoppslag.database.VilkårsvurderingRepository
 import no.nav.aap.arenaoppslag.modeller.ArenaSakMedVedtak
 import no.nav.aap.arenaoppslag.modeller.toArenaSakMedVedtak
 
@@ -10,15 +11,24 @@ class SakOgVedtakService(
     private val sakRepository: SakRepository,
     private val vedtakRepository: VedtakRepository,
     private val vedtakfaktaRepository: VedtakfaktaRepository,
+    private val vilkårsvurderingRepository: VilkårsvurderingRepository,
 ) {
     fun hentSakMedVedtak(saksId: Int): ArenaSakMedVedtak? {
         val sak = sakRepository.hentSak(saksId) ?: return null
 
         val vedtak = vedtakRepository.hentVedtakForSak(saksId)
-        val faktaPerVedtak = vedtakfaktaRepository.hentForVedtakIder(vedtak.map { it.vedtakId })
+        val vedtakIder = vedtak.map { it.vedtakId }
 
-        val vedtakMedFakta = vedtak.map { it.medFakta(faktaPerVedtak[it.vedtakId] ?: emptyList()) }
+        val faktaPerVedtak = vedtakfaktaRepository.hentForVedtakIder(vedtakIder)
+        val vilkårsvurderingerPerVedtak = vilkårsvurderingRepository.hentForVedtakIder(vedtakIder)
 
-        return sak.toArenaSakMedVedtak(vedtakMedFakta)
+        val vedtakMedFaktaOgVilkår = vedtak.map { v ->
+            v.medFakta(
+                fakta = faktaPerVedtak[v.vedtakId] ?: emptyList(),
+                vilkårsvurderinger = vilkårsvurderingerPerVedtak[v.vedtakId] ?: emptyList(),
+            )
+        }
+
+        return sak.toArenaSakMedVedtak(vedtakMedFaktaOgVilkår)
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -4,7 +4,7 @@ import no.nav.aap.arenaoppslag.database.DbDato.fraDato
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Periode
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
-import no.nav.aap.arenaoppslag.modeller.ArenaVedtakUtenFakta
+import no.nav.aap.arenaoppslag.modeller.ArenaVedtakRad
 import no.nav.aap.arenaoppslag.modeller.VedtakStatus
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.TestOnly
@@ -29,7 +29,7 @@ class VedtakRepository(private val dataSource: DataSource) {
         }
     }
 
-    fun hentVedtakForSak(saksId: Int): List<ArenaVedtakUtenFakta> {
+    fun hentVedtakForSak(saksId: Int): List<ArenaVedtakRad> {
         return dataSource.connection.use { con ->
             selectVedtakForSak(saksId, con)
         }
@@ -111,15 +111,15 @@ class VedtakRepository(private val dataSource: DataSource) {
            AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
-        private fun selectVedtakForSak(sakId: Int, connection: Connection): List<ArenaVedtakUtenFakta> {
+        private fun selectVedtakForSak(sakId: Int, connection: Connection): List<ArenaVedtakRad> {
             connection.createParameterizedQuery(selectVedtakForSak).use { preparedStatement ->
                 preparedStatement.setInt(1, sakId)
                 val resultSet = preparedStatement.executeQuery()
-                return resultSet.map { mapperForArenaVedtakUtenFakta(it) }.toList()
+                return resultSet.map { mapperForArenaVedtakRad(it) }.toList()
             }
         }
 
-        private fun mapperForArenaVedtakUtenFakta(row: ResultSet) = ArenaVedtakUtenFakta(
+        private fun mapperForArenaVedtakRad(row: ResultSet) = ArenaVedtakRad(
             vedtakId = row.getInt("vedtak_id"),
             statusKode = row.getString("vedtakstatuskode"),
             statusNavn = row.getString("vedtakstatusnavn"),

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -4,8 +4,7 @@ import no.nav.aap.arenaoppslag.database.DbDato.fraDato
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Periode
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
-import no.nav.aap.arenaoppslag.modeller.ArenaVedtakMedFakta
-import no.nav.aap.arenaoppslag.modeller.ArenaVedtakfakta
+import no.nav.aap.arenaoppslag.modeller.ArenaVedtakUtenFakta
 import no.nav.aap.arenaoppslag.modeller.VedtakStatus
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.TestOnly
@@ -30,17 +29,9 @@ class VedtakRepository(private val dataSource: DataSource) {
         }
     }
 
-    fun hentVedtakMedFaktaForSak(saksId: Int): List<ArenaVedtakMedFakta> {
+    fun hentVedtakForSak(saksId: Int): List<ArenaVedtakUtenFakta> {
         return dataSource.connection.use { con ->
-            selectVedtakMedFaktaForSak(saksId, con)
-                .groupBy { it.vedtakId }
-                .values
-                .map { vedtakMedFakta ->
-                    val vedtakFakta = vedtakMedFakta.mapNotNull { it.tilArenaVedtakFakta() }
-                    vedtakMedFakta
-                        .first()
-                        .tilArenaVedtakMedFakta(vedtakFakta)
-                }
+            selectVedtakForSak(saksId, con)
         }
     }
 
@@ -107,94 +98,39 @@ class VedtakRepository(private val dataSource: DataSource) {
 
 
         @Language("OracleSql")
-        private val selectVedtakMedFaktaForSak = """
-        SELECT v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn, v.fra_dato, v.til_dato, v.rettighetkode, v.utfallkode, vf.vedtak_id, 
-            vf.vedtakfaktakode, vf.vedtakverdi, vf.reg_dato, vft.skjermbildetekst, a.aktfasekode, a.aktfasenavn
+        private val selectVedtakForSak = """
+        SELECT v.vedtak_id, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
+               v.fra_dato, v.til_dato, v.rettighetkode, v.utfallkode,
+               a.aktfasekode, a.aktfasenavn
           FROM vedtak v
           LEFT JOIN vedtaktype vt ON vt.vedtaktypekode = v.vedtaktypekode
           LEFT JOIN vedtakstatus vs ON v.vedtakstatuskode = vs.vedtakstatuskode
-          LEFT JOIN vedtakfakta vf ON  vf.vedtak_id = v.vedtak_id
-          LEFT JOIN vedtakfaktatype vft ON vf.vedtakfaktakode = vft.vedtakfaktakode
           LEFT JOIN aktivitetfase a ON a.aktfasekode = v.aktfasekode
          WHERE sak_id = ?
            AND v.rettighetkode = 'AAP'
            AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
-        private fun selectVedtakMedFaktaForSak(sakId: Int, connection: Connection): List<ArenaVedtakMedFaktaRow> {
-            connection.prepareStatement(selectVedtakMedFaktaForSak).use { preparedStatement ->
+        private fun selectVedtakForSak(sakId: Int, connection: Connection): List<ArenaVedtakUtenFakta> {
+            connection.createParameterizedQuery(selectVedtakForSak).use { preparedStatement ->
                 preparedStatement.setInt(1, sakId)
                 val resultSet = preparedStatement.executeQuery()
-                return resultSet.map { ArenaVedtakMedFaktaRow.fromResultRow(it) }.toList()
+                return resultSet.map { mapperForArenaVedtakUtenFakta(it) }.toList()
             }
         }
-    }
 
-
-    private data class ArenaVedtakMedFaktaRow(
-        val statusKode: String,
-        val statusNavn: String,
-        val vedtaktypeKode: String,
-        val vedtaktypeNavn: String,
-        val fraOgMed: LocalDate?,
-        val tilDato: LocalDate?,
-        val rettighetkode: String,
-        val utfallkode: String?,
-        val vedtakId: Int,
-        val vedtakfaktakode: String?,
-        val vedtakfaktakodeverdi: String?,
-        val aktivitetsfaseKode: String,
-        val aktivitetsfaseNavn: String,
-        val vedtakfaktanavn: String?,
-        val vedtakfaktakoderegistrertDato: LocalDate?,
-    ) {
-        companion object {
-            fun fromResultRow(row: ResultSet) = ArenaVedtakMedFaktaRow(
-                statusKode = row.getString("vedtakstatuskode"),
-                statusNavn =  row.getString("vedtakstatusnavn"),
-                vedtaktypeKode = row.getString("vedtaktypekode"),
-                vedtaktypeNavn = row.getString("vedtaktypenavn"),
-                aktivitetsfaseKode = row.getString("aktfasekode"),
-                aktivitetsfaseNavn = row.getString("aktfasenavn"),
-                fraOgMed = fraDato(row.getDate("fra_dato")),
-                tilDato = fraDato(row.getDate("til_dato")),
-                rettighetkode = row.getString("rettighetkode"),
-                utfallkode = row.getString("utfallkode"),
-                vedtakId = row.getInt("vedtak_id"),
-                vedtakfaktakode = row.getString("vedtakfaktakode"),
-                vedtakfaktakodeverdi = row.getString("vedtakverdi"),
-                vedtakfaktakoderegistrertDato = row.getDate("reg_dato")?.toLocalDate(),
-                vedtakfaktanavn = row.getString("skjermbildetekst"),
-            )
-        }
-
-        fun tilArenaVedtakMedFakta(fakta: List<ArenaVedtakfakta>) =
-            ArenaVedtakMedFakta(
-                vedtakId = vedtakId,
-                statusKode = statusKode,
-                statusNavn = statusNavn,
-                vedtaktypeKode = vedtaktypeKode,
-                vedtaktypeNavn = vedtaktypeNavn,
-                aktivitetsfaseKode = aktivitetsfaseKode,
-                aktivitetsfaseNavn = aktivitetsfaseNavn,
-                fraOgMed = fraOgMed,
-                tilDato = tilDato,
-                rettighetkode = rettighetkode,
-                utfallkode = utfallkode,
-                fakta = fakta
-            )
-
-        fun tilArenaVedtakFakta(): ArenaVedtakfakta? {
-            if (vedtakfaktakode == null || vedtakfaktakoderegistrertDato == null || vedtakfaktanavn == null) {
-                return null
-            }
-            return ArenaVedtakfakta(
-                kode = vedtakfaktakode,
-                navn = vedtakfaktanavn,
-                verdi = vedtakfaktakodeverdi,
-                registrertDato = vedtakfaktakoderegistrertDato
-            )
-        }
-
+        private fun mapperForArenaVedtakUtenFakta(row: ResultSet) = ArenaVedtakUtenFakta(
+            vedtakId = row.getInt("vedtak_id"),
+            statusKode = row.getString("vedtakstatuskode"),
+            statusNavn = row.getString("vedtakstatusnavn"),
+            vedtaktypeKode = row.getString("vedtaktypekode"),
+            vedtaktypeNavn = row.getString("vedtaktypenavn"),
+            aktivitetsfaseKode = row.getString("aktfasekode"),
+            aktivitetsfaseNavn = row.getString("aktfasenavn"),
+            fraOgMed = fraDato(row.getDate("fra_dato")),
+            tilDato = fraDato(row.getDate("til_dato")),
+            rettighetkode = row.getString("rettighetkode"),
+            utfallkode = row.getString("utfallkode"),
+        )
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -99,7 +99,7 @@ class VedtakRepository(private val dataSource: DataSource) {
 
         @Language("OracleSql")
         private val selectVedtakForSak = """
-        SELECT v.vedtak_id, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
+        SELECT v.vedtak_id, v.lopenrvedtak, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
                v.fra_dato, v.til_dato, v.rettighetkode, v.utfallkode,
                a.aktfasekode, a.aktfasenavn
           FROM vedtak v
@@ -121,6 +121,7 @@ class VedtakRepository(private val dataSource: DataSource) {
 
         private fun mapperForArenaVedtakRad(row: ResultSet) = ArenaVedtakRad(
             vedtakId = row.getInt("vedtak_id"),
+            lopenrvedtak = row.getInt("lopenrvedtak"),
             statusKode = row.getString("vedtakstatuskode"),
             statusNavn = row.getString("vedtakstatusnavn"),
             vedtaktypeKode = row.getString("vedtaktypekode"),

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakfaktaRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakfaktaRepository.kt
@@ -1,0 +1,65 @@
+package no.nav.aap.arenaoppslag.database
+
+import no.nav.aap.arenaoppslag.modeller.ArenaVedtakfakta
+import org.intellij.lang.annotations.Language
+import java.sql.ResultSet
+import java.time.LocalDate
+import javax.sql.DataSource
+
+class VedtakfaktaRepository(private val dataSource: DataSource) {
+
+    fun hentForVedtakIder(vedtakIder: List<Int>): Map<Int, List<ArenaVedtakfakta>> {
+        if (vedtakIder.isEmpty()) return emptyMap()
+
+        return dataSource.connection.use { con ->
+            val query = queryMedVedtakIdListe(vedtakIder)
+            con.createParameterizedQuery(query).use { preparedStatement ->
+                preparedStatement.executeQuery()
+                    .map { row -> mapperForVedtakfaktaRad(row) }
+                    .groupBy { it.vedtakId }
+                    .mapValues { (_, rader) -> rader.map { it.tilArenaVedtakfakta() } }
+            }
+        }
+    }
+
+    companion object {
+        private const val VEDTAK_ID_LISTE_TOKEN = "?:vedtakider"
+
+        private fun queryMedVedtakIdListe(vedtakIder: List<Int>): String {
+            // Oracle støtter ikke listeparametere i PreparedStatement, så vi interpolerer direkte
+            val idListe = vedtakIder.joinToString(separator = ",")
+            return selectVedtakfaktaForVedtakIder.replace(VEDTAK_ID_LISTE_TOKEN, idListe)
+        }
+
+        @Language("OracleSql")
+        private val selectVedtakfaktaForVedtakIder = """
+            SELECT vf.vedtak_id, vf.vedtakfaktakode, vf.vedtakverdi, vf.reg_dato, vft.skjermbildetekst
+              FROM vedtakfakta vf
+              LEFT JOIN vedtakfaktatype vft ON vft.vedtakfaktakode = vf.vedtakfaktakode
+             WHERE vf.vedtak_id IN ($VEDTAK_ID_LISTE_TOKEN)
+        """.trimIndent()
+
+        private data class VedtakfaktaRad(
+            val vedtakId: Int,
+            val kode: String,
+            val navn: String,
+            val verdi: String?,
+            val registrertDato: LocalDate,
+        ) {
+            fun tilArenaVedtakfakta() = ArenaVedtakfakta(
+                kode = kode,
+                navn = navn,
+                verdi = verdi,
+                registrertDato = registrertDato,
+            )
+        }
+
+        private fun mapperForVedtakfaktaRad(row: ResultSet) = VedtakfaktaRad(
+            vedtakId = row.getInt("vedtak_id"),
+            kode = row.getString("vedtakfaktakode"),
+            navn = row.getString("skjermbildetekst"),
+            verdi = row.getString("vedtakverdi"),
+            registrertDato = row.getDate("reg_dato").toLocalDate(),
+        )
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VilkårsvurderingRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VilkårsvurderingRepository.kt
@@ -1,0 +1,62 @@
+package no.nav.aap.arenaoppslag.database
+
+import no.nav.aap.arenaoppslag.modeller.ArenaVilkårsvurdering
+import org.intellij.lang.annotations.Language
+import java.sql.ResultSet
+import javax.sql.DataSource
+
+class VilkårsvurderingRepository(private val dataSource: DataSource) {
+
+    fun hentForVedtakIder(vedtakIder: List<Int>): Map<Int, List<ArenaVilkårsvurdering>> {
+        if (vedtakIder.isEmpty()) return emptyMap()
+
+        return dataSource.connection.use { con ->
+            val query = queryMedVedtakIdListe(vedtakIder)
+            con.createParameterizedQuery(query).use { preparedStatement ->
+                preparedStatement.executeQuery()
+                    .map { row -> mapperForVilkårsvurderingRad(row) }
+                    .groupBy { it.first }
+                    .mapValues { (_, rader) -> rader.map { it.second } }
+            }
+        }
+    }
+
+    companion object {
+        private const val VEDTAK_ID_LISTE_TOKEN = "?:vedtakider"
+
+        private fun queryMedVedtakIdListe(vedtakIder: List<Int>): String {
+            // Oracle støtter ikke listeparametere i PreparedStatement, så vi interpolerer direkte
+            val idListe = vedtakIder.joinToString(separator = ",")
+            return selectVilkårsvurderingerForVedtakIder.replace(VEDTAK_ID_LISTE_TOKEN, idListe)
+        }
+
+        @Language("OracleSql")
+        private val selectVilkårsvurderingerForVedtakIder = """
+            SELECT vv.vilkaarvurdering_id, vv.vedtak_id, vv.vilkaarkode, vv.begrunnelse, vv.vurdert_av,
+                   vt.skjermbildetekst, vt.status_oblig, vt.url_hjelpereferanse, vt.url_lovtekst, vt.url_rundskrivtekst,
+                   vs.vilkaarstatuskode, vs.vilkaarstatusnavn
+              FROM vilkaarvurdering vv
+              LEFT JOIN vilkaartype vt ON vt.vilkaarkode = vv.vilkaarkode
+              LEFT JOIN vilkaarstatus vs ON vs.vilkaarstatuskode = vv.vilkaarstatuskode
+             WHERE vv.vedtak_id IN ($VEDTAK_ID_LISTE_TOKEN)
+        """.trimIndent()
+
+        private fun mapperForVilkårsvurderingRad(row: ResultSet): Pair<Int, ArenaVilkårsvurdering> {
+            val vedtakId = row.getInt("vedtak_id")
+            val vilkårsvurdering = ArenaVilkårsvurdering(
+                vilkårsvurderingId = row.getLong("vilkaarvurdering_id"),
+                vilkårkode = row.getString("vilkaarkode"),
+                begrunnelse = row.getString("begrunnelse"),
+                vurdertAv = row.getString("vurdert_av"),
+                vilkårnavn = row.getString("skjermbildetekst"),
+                erObligatorisk = row.getString("status_oblig") == "J",
+                hjelpetekstUrl = row.getString("url_hjelpereferanse"),
+                lovtekstUrl = row.getString("url_lovtekst"),
+                rundskrivUrl = row.getString("url_rundskrivtekst"),
+                statuskode = row.getString("vilkaarstatuskode"),
+                statusnavn = row.getString("vilkaarstatusnavn"),
+            )
+            return vedtakId to vilkårsvurdering
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ApiResponse.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ApiResponse.kt
@@ -11,7 +11,7 @@ data class ArenaSakDetaljertRespons(
     val statusnavn: String,
     val registrertDato: LocalDateTime,
     val avsluttetDato: LocalDateTime?,
-    val vedtak: List<ArenaVedtakMedFakta>,
+    val vedtak: List<ArenaVedtakMedDetaljer>,
     val tellerverk: TellerverkPåPerson?
 ) {
     companion object {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
@@ -22,7 +22,7 @@ data class ArenaSakMedVedtak (
     val statusnavn: String,
     val registrertDato: LocalDateTime,
     val avsluttetDato: LocalDateTime?,
-    val vedtak: List<ArenaVedtakMedFakta>
+    val vedtak: List<ArenaVedtakMedDetaljer>
 )
 
 data class ArenaSakPerson (
@@ -32,7 +32,7 @@ data class ArenaSakPerson (
     val etternavn: String,
 )
 
-fun ArenaSak.toArenaSakMedVedtak(vedtak: List<ArenaVedtakMedFakta>) =
+fun ArenaSak.toArenaSakMedVedtak(vedtak: List<ArenaVedtakMedDetaljer>) =
     ArenaSakMedVedtak(
         sakId = sakId,
         opprettetAar = opprettetAar,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -22,7 +22,7 @@ data class ArenaVedtak(
     val utfallkode: String?
 )
 
-data class ArenaVedtakUtenFakta(
+data class ArenaVedtakRad(
     val vedtakId: Int,
     val statusKode: String,
     val statusNavn: String,
@@ -35,7 +35,10 @@ data class ArenaVedtakUtenFakta(
     val rettighetkode: String,
     val utfallkode: String?,
 ) {
-    fun medFakta(fakta: List<ArenaVedtakfakta>) = ArenaVedtakMedFakta(
+    fun medFakta(
+        fakta: List<ArenaVedtakfakta>,
+        vilkårsvurderinger: List<ArenaVilkårsvurdering> = emptyList(),
+    ) = ArenaVedtakMedDetaljer(
         vedtakId = vedtakId,
         statusKode = statusKode,
         statusNavn = statusNavn,
@@ -48,10 +51,11 @@ data class ArenaVedtakUtenFakta(
         rettighetkode = rettighetkode,
         utfallkode = utfallkode,
         fakta = fakta,
+        vilkårsvurderinger = vilkårsvurderinger,
     )
 }
 
-data class ArenaVedtakMedFakta(
+data class ArenaVedtakMedDetaljer(
     val vedtakId: Int,
     val statusKode: String,
     val statusNavn: String,
@@ -63,7 +67,8 @@ data class ArenaVedtakMedFakta(
     val tilDato: LocalDate?,
     val rettighetkode: String,
     val utfallkode: String?,
-    val fakta: List<ArenaVedtakfakta>
+    val fakta: List<ArenaVedtakfakta>,
+    val vilkårsvurderinger: List<ArenaVilkårsvurdering> = emptyList(),
 )
 
 data class ArenaVedtakfakta(
@@ -71,4 +76,18 @@ data class ArenaVedtakfakta(
     val navn: String,
     val verdi: String?,
     val registrertDato: LocalDate,
+)
+
+data class ArenaVilkårsvurdering(
+    val vilkårsvurderingId: Long,
+    val vilkårkode: String,
+    val begrunnelse: String?,
+    val vurdertAv: String?,
+    val vilkårnavn: String,
+    val erObligatorisk: Boolean,
+    val hjelpetekstUrl: String?,
+    val lovtekstUrl: String?,
+    val rundskrivUrl: String?,
+    val statuskode: String,
+    val statusnavn: String,
 )

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -22,8 +22,37 @@ data class ArenaVedtak(
     val utfallkode: String?
 )
 
+data class ArenaVedtakUtenFakta(
+    val vedtakId: Int,
+    val statusKode: String,
+    val statusNavn: String,
+    val vedtaktypeKode: String,
+    val vedtaktypeNavn: String,
+    val aktivitetsfaseKode: String,
+    val aktivitetsfaseNavn: String,
+    val fraOgMed: LocalDate?,
+    val tilDato: LocalDate?,
+    val rettighetkode: String,
+    val utfallkode: String?,
+) {
+    fun medFakta(fakta: List<ArenaVedtakfakta>) = ArenaVedtakMedFakta(
+        vedtakId = vedtakId,
+        statusKode = statusKode,
+        statusNavn = statusNavn,
+        vedtaktypeKode = vedtaktypeKode,
+        vedtaktypeNavn = vedtaktypeNavn,
+        aktivitetsfaseKode = aktivitetsfaseKode,
+        aktivitetsfaseNavn = aktivitetsfaseNavn,
+        fraOgMed = fraOgMed,
+        tilDato = tilDato,
+        rettighetkode = rettighetkode,
+        utfallkode = utfallkode,
+        fakta = fakta,
+    )
+}
+
 data class ArenaVedtakMedFakta(
-    val vedtakId : Int,
+    val vedtakId: Int,
     val statusKode: String,
     val statusNavn: String,
     val vedtaktypeKode: String,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -24,6 +24,7 @@ data class ArenaVedtak(
 
 data class ArenaVedtakRad(
     val vedtakId: Int,
+    val lopenrvedtak: Int,
     val statusKode: String,
     val statusNavn: String,
     val vedtaktypeKode: String,
@@ -40,6 +41,7 @@ data class ArenaVedtakRad(
         vilkårsvurderinger: List<ArenaVilkårsvurdering> = emptyList(),
     ) = ArenaVedtakMedDetaljer(
         vedtakId = vedtakId,
+        lopenrvedtak = lopenrvedtak,
         statusKode = statusKode,
         statusNavn = statusNavn,
         vedtaktypeKode = vedtaktypeKode,
@@ -57,6 +59,7 @@ data class ArenaVedtakRad(
 
 data class ArenaVedtakMedDetaljer(
     val vedtakId: Int,
+    val lopenrvedtak: Int,
     val statusKode: String,
     val statusNavn: String,
     val vedtaktypeKode: String,

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.aap.arenaoppslag.database
 
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
-import no.nav.aap.arenaoppslag.modeller.ArenaVedtakUtenFakta
+import no.nav.aap.arenaoppslag.modeller.ArenaVedtakRad
 import no.nav.aap.arenaoppslag.modeller.VedtakStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -33,7 +33,7 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
     @Test
     fun `hentVedtakForSak klarer å hente alle vedtak fra databasen`() {
         val vedtakRepository = VedtakRepository(h2)
-        val forventetVedtak = ArenaVedtakUtenFakta(
+        val forventetVedtak = ArenaVedtakRad(
             vedtakId = 1234,
             statusKode = "IVERK",
             statusNavn = "Iverksatt",

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.aap.arenaoppslag.database
 
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
-import no.nav.aap.arenaoppslag.modeller.ArenaVedtakMedFakta
+import no.nav.aap.arenaoppslag.modeller.ArenaVedtakUtenFakta
 import no.nav.aap.arenaoppslag.modeller.VedtakStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -31,10 +31,10 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
     }
 
     @Test
-    fun `hentVedtakMedFaktaForSak klarer å hente alle vedtak fra databasen`() {
+    fun `hentVedtakForSak klarer å hente alle vedtak fra databasen`() {
         val vedtakRepository = VedtakRepository(h2)
-        val forventetVedtak = ArenaVedtakMedFakta(
-            vedtakId = 0,
+        val forventetVedtak = ArenaVedtakUtenFakta(
+            vedtakId = 1234,
             statusKode = "IVERK",
             statusNavn = "Iverksatt",
             vedtaktypeKode = "O",
@@ -45,18 +45,18 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
             tilDato = LocalDate.of(2023, 8, 30),
             rettighetkode = "AAP",
             utfallkode = "JA",
-            fakta = emptyList()
         )
 
-        val alleVedtak = vedtakRepository.hentVedtakMedFaktaForSak(1)
+        val alleVedtak = vedtakRepository.hentVedtakForSak(1)
 
         assertThat(alleVedtak).containsExactly(forventetVedtak)
     }
 
     @Test
-    fun `hentVedtakMedFaktaForSak returnerer tom liste om det ikke er noen vedtak knyttet til denne saken`() {
+    fun `hentVedtakForSak returnerer tom liste om det ikke er noen vedtak knyttet til denne saken`() {
         val vedtakRepository = VedtakRepository(h2)
-        val alleVedtak = vedtakRepository.hentVedtakMedFaktaForSak(1919191919)
+        val alleVedtak = vedtakRepository.hentVedtakForSak(1919191919)
         assertThat(alleVedtak).isEmpty()
     }
 }
+

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -35,6 +35,7 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
         val vedtakRepository = VedtakRepository(h2)
         val forventetVedtak = ArenaVedtakRad(
             vedtakId = 1234,
+            lopenrvedtak = 1,
             statusKode = "IVERK",
             statusNavn = "Iverksatt",
             vedtaktypeKode = "O",

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakfaktaRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakfaktaRepositoryTest.kt
@@ -1,0 +1,41 @@
+package no.nav.aap.arenaoppslag.database
+
+import no.nav.aap.arenaoppslag.modeller.ArenaVedtakfakta
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class VedtakfaktaRepositoryTest : H2TestBase("flyway/minimumtest") {
+
+    private val repo = VedtakfaktaRepository(h2)
+
+    @Test
+    fun `henter vedtakfakta for kjent vedtakId`() {
+        // VEDTAK_ID 37067849 har én DAGS-fakta fra V1_3__arena_data.sql
+        val resultat = repo.hentForVedtakIder(listOf(37067849))
+
+        assertThat(resultat).containsKey(37067849)
+        assertThat(resultat[37067849]).containsExactly(
+            ArenaVedtakfakta(
+                kode = "DAGS",
+                navn = "Dagsats",
+                verdi = "255",
+                registrertDato = LocalDate.of(2025, 3, 28),
+            )
+        )
+    }
+
+    @Test
+    fun `returnerer tom map for ukjent vedtakId`() {
+        val resultat = repo.hentForVedtakIder(listOf(999999999))
+
+        assertThat(resultat).isEmpty()
+    }
+
+    @Test
+    fun `returnerer tom map for tom liste`() {
+        val resultat = repo.hentForVedtakIder(emptyList())
+
+        assertThat(resultat).isEmpty()
+    }
+}

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VilkårsvurderingRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VilkårsvurderingRepositoryTest.kt
@@ -1,0 +1,58 @@
+package no.nav.aap.arenaoppslag.database
+
+import no.nav.aap.arenaoppslag.modeller.ArenaVilkårsvurdering
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class VilkårsvurderingRepositoryTest : H2TestBase("flyway/minimumtest") {
+
+    private val repo = VilkårsvurderingRepository(h2)
+
+    @Test
+    fun `henter vilkårsvurderinger for kjent vedtakId`() {
+        // vedtak_id=1234 har to vilkårsvurderinger fra V1_6__insert_vilkaarsvurdering.sql
+        val resultat = repo.hentForVedtakIder(listOf(1234))
+
+        assertThat(resultat).containsKey(1234)
+        val vurderinger = resultat[1234]!!
+        assertThat(vurderinger).hasSize(2)
+
+        val oppfylt = vurderinger.find { it.vilkårsvurderingId == 1001L }!!
+        assertThat(oppfylt.vilkårkode).isEqualTo("OPPHINST")
+        assertThat(oppfylt.statuskode).isEqualTo("J")
+        assertThat(oppfylt.statusnavn).isEqualTo("Oppfylt")
+        assertThat(oppfylt.begrunnelse).isEqualTo("Vilkåret er oppfylt")
+        assertThat(oppfylt.vurdertAv).isEqualTo("TEST01")
+        assertThat(oppfylt.erObligatorisk).isTrue()
+
+        val ikkeOppfylt = vurderinger.find { it.vilkårsvurderingId == 1002L }!!
+        assertThat(ikkeOppfylt.vilkårkode).isEqualTo("PAASTAND")
+        assertThat(ikkeOppfylt.statuskode).isEqualTo("N")
+        assertThat(ikkeOppfylt.statusnavn).isEqualTo("Ikke oppfylt")
+        assertThat(ikkeOppfylt.begrunnelse).isNull()
+    }
+
+    @Test
+    fun `returnerer tom map for ukjent vedtakId`() {
+        val resultat = repo.hentForVedtakIder(listOf(999999999))
+
+        assertThat(resultat).isEmpty()
+    }
+
+    @Test
+    fun `returnerer tom map for tom liste`() {
+        val resultat = repo.hentForVedtakIder(emptyList())
+
+        assertThat(resultat).isEmpty()
+    }
+
+    @Test
+    fun `henter vilkårsvurderinger for flere vedtakIder i én spørring`() {
+        // vedtak_id=1234 har data, vedtak_id=4321 har ingen
+        val resultat = repo.hentForVedtakIder(listOf(1234, 4321))
+
+        assertThat(resultat).containsKey(1234)
+        assertThat(resultat).doesNotContainKey(4321)
+        assertThat(resultat[1234]).hasSize(2)
+    }
+}

--- a/app/src/test/resources/flyway/minimumtest/V1_8__insert_vilkaarsvurdering.sql
+++ b/app/src/test/resources/flyway/minimumtest/V1_8__insert_vilkaarsvurdering.sql
@@ -1,0 +1,16 @@
+-- Vilkårsvurderinger for vedtak_id=1234 (sak_id=1, person 123)
+-- Bruker vilkårkoder som finnes i VILKAARTYPE fra V1_2__arena_konstanter.sql
+
+Insert into VILKAARVURDERING (VILKAARVURDERING_ID, VEDTAKTYPEKODE, VILKAARKODE, VEDTAK_ID, REG_DATO, REG_USER,
+                               MOD_DATO, MOD_USER, RETTIGHETKODE, AKTFASEKODE, VILKAARSTATUSKODE, VURDERT_AV,
+                               BEGRUNNELSE)
+values (1001, 'O', 'OPPHINST', 1234, DATE '2022-08-30', 'TEST',
+        DATE '2022-08-30', 'TEST', 'AAP', 'IKKE', 'J', 'TEST01',
+        'Vilkåret er oppfylt');
+
+Insert into VILKAARVURDERING (VILKAARVURDERING_ID, VEDTAKTYPEKODE, VILKAARKODE, VEDTAK_ID, REG_DATO, REG_USER,
+                               MOD_DATO, MOD_USER, RETTIGHETKODE, AKTFASEKODE, VILKAARSTATUSKODE, VURDERT_AV,
+                               BEGRUNNELSE)
+values (1002, 'O', 'PAASTAND', 1234, DATE '2022-08-30', 'TEST',
+        DATE '2022-08-30', 'TEST', 'AAP', 'IKKE', 'N', 'TEST01',
+        null);


### PR DESCRIPTION
Trekker ut vedtakfakta i eget repository (`VedtakfaktaRepository`) og forenkler `VedtakRepository`. Legger til vilkårsvurderinger (`VILKAARVURDERING`) og `lopenrvedtak` på hvert vedtak i `/api/intern/sak/{sakid}/detaljert`-responsen. Omdøper interne domenetyper: `ArenaVedtakUtenFakta` → `ArenaVedtakRad`, `ArenaVedtakMedFakta` → `ArenaVedtakMedDetaljer`.