### PR TITLE
Inkluder alle vedtak og rettighetnavn i sak-detaljert-endepunktet

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -100,14 +100,14 @@ class VedtakRepository(private val dataSource: DataSource) {
         @Language("OracleSql")
         private val selectVedtakForSak = """
         SELECT v.vedtak_id, v.lopenrvedtak, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
-               v.fra_dato, v.til_dato, v.rettighetkode, v.utfallkode,
+               v.fra_dato, v.til_dato, v.rettighetkode, rt.rettighetnavn, v.utfallkode,
                a.aktfasekode, a.aktfasenavn
           FROM vedtak v
           LEFT JOIN vedtaktype vt ON vt.vedtaktypekode = v.vedtaktypekode
           LEFT JOIN vedtakstatus vs ON v.vedtakstatuskode = vs.vedtakstatuskode
           LEFT JOIN aktivitetfase a ON a.aktfasekode = v.aktfasekode
+          LEFT JOIN rettighettype rt ON rt.rettighetkode = v.rettighetkode
          WHERE sak_id = ?
-           AND v.rettighetkode = 'AAP'
            AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
@@ -131,6 +131,7 @@ class VedtakRepository(private val dataSource: DataSource) {
             fraOgMed = fraDato(row.getDate("fra_dato")),
             tilDato = fraDato(row.getDate("til_dato")),
             rettighetkode = row.getString("rettighetkode"),
+            rettighetnavn = row.getString("rettighetnavn"),
             utfallkode = row.getString("utfallkode"),
         )
     }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -34,6 +34,7 @@ data class ArenaVedtakRad(
     val fraOgMed: LocalDate?,
     val tilDato: LocalDate?,
     val rettighetkode: String,
+    val rettighetnavn: String,
     val utfallkode: String?,
 ) {
     fun medFakta(
@@ -51,6 +52,7 @@ data class ArenaVedtakRad(
         fraOgMed = fraOgMed,
         tilDato = tilDato,
         rettighetkode = rettighetkode,
+        rettighetnavn = rettighetnavn,
         utfallkode = utfallkode,
         fakta = fakta,
         vilkårsvurderinger = vilkårsvurderinger,
@@ -69,6 +71,7 @@ data class ArenaVedtakMedDetaljer(
     val fraOgMed: LocalDate?,
     val tilDato: LocalDate?,
     val rettighetkode: String,
+    val rettighetnavn: String,
     val utfallkode: String?,
     val fakta: List<ArenaVedtakfakta>,
     val vilkårsvurderinger: List<ArenaVilkårsvurdering> = emptyList(),

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -45,6 +45,7 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
             fraOgMed = LocalDate.of(2022, 8, 30),
             tilDato = LocalDate.of(2023, 8, 30),
             rettighetkode = "AAP",
+            rettighetnavn = "Arbeidsavklaringspenger",
             utfallkode = "JA",
         )
 


### PR DESCRIPTION
Fjerner filteret rettighetkode = 'AAP' fra hentVedtakForSak slik at endepunktet returnerer alle vedtak på saken. Legger til JOIN mot rettighettype og eksponerer rettighetnavn i responsen.