### PR TITLE
Legg til saksbehandler, beslutter og begrunnelse på vedtak i sak-detaljert-endepunktet

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -101,6 +101,7 @@ class VedtakRepository(private val dataSource: DataSource) {
         private val selectVedtakForSak = """
         SELECT v.vedtak_id, v.lopenrvedtak, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
                v.fra_dato, v.til_dato, v.rettighetkode, rt.rettighetnavn, v.utfallkode,
+               v.brukerid_ansvarlig, v.brukerid_beslutter,
                a.aktfasekode, a.aktfasenavn
           FROM vedtak v
           LEFT JOIN vedtaktype vt ON vt.vedtaktypekode = v.vedtaktypekode
@@ -133,6 +134,8 @@ class VedtakRepository(private val dataSource: DataSource) {
             rettighetkode = row.getString("rettighetkode"),
             rettighetnavn = row.getString("rettighetnavn"),
             utfallkode = row.getString("utfallkode"),
+            saksbehandler = row.getString("brukerid_ansvarlig"),
+            beslutter = row.getString("brukerid_beslutter"),
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -100,7 +100,7 @@ class VedtakRepository(private val dataSource: DataSource) {
         @Language("OracleSql")
         private val selectVedtakForSak = """
         SELECT v.vedtak_id, v.lopenrvedtak, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
-               v.fra_dato, v.til_dato, v.rettighetkode, rt.rettighetnavn, v.utfallkode,
+               v.fra_dato, v.til_dato, v.rettighetkode, rt.rettighetnavn, v.utfallkode, v.begrunnelse,
                v.brukerid_ansvarlig, v.brukerid_beslutter,
                a.aktfasekode, a.aktfasenavn
           FROM vedtak v
@@ -134,6 +134,7 @@ class VedtakRepository(private val dataSource: DataSource) {
             rettighetkode = row.getString("rettighetkode"),
             rettighetnavn = row.getString("rettighetnavn"),
             utfallkode = row.getString("utfallkode"),
+            begrunnelse = row.getString("begrunnelse"),
             saksbehandler = row.getString("brukerid_ansvarlig"),
             beslutter = row.getString("brukerid_beslutter"),
         )

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -36,6 +36,7 @@ data class ArenaVedtakRad(
     val rettighetkode: String,
     val rettighetnavn: String,
     val utfallkode: String?,
+    val begrunnelse: String?,
     val saksbehandler: String?,
     val beslutter: String?,
 ) {
@@ -56,6 +57,7 @@ data class ArenaVedtakRad(
         rettighetkode = rettighetkode,
         rettighetnavn = rettighetnavn,
         utfallkode = utfallkode,
+        begrunnelse = begrunnelse,
         saksbehandler = saksbehandler,
         beslutter = beslutter,
         fakta = fakta,
@@ -77,6 +79,7 @@ data class ArenaVedtakMedDetaljer(
     val rettighetkode: String,
     val rettighetnavn: String,
     val utfallkode: String?,
+    val begrunnelse: String?,
     val saksbehandler: String?,
     val beslutter: String?,
     val fakta: List<ArenaVedtakfakta>,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -36,6 +36,8 @@ data class ArenaVedtakRad(
     val rettighetkode: String,
     val rettighetnavn: String,
     val utfallkode: String?,
+    val saksbehandler: String?,
+    val beslutter: String?,
 ) {
     fun medFakta(
         fakta: List<ArenaVedtakfakta>,
@@ -54,6 +56,8 @@ data class ArenaVedtakRad(
         rettighetkode = rettighetkode,
         rettighetnavn = rettighetnavn,
         utfallkode = utfallkode,
+        saksbehandler = saksbehandler,
+        beslutter = beslutter,
         fakta = fakta,
         vilkårsvurderinger = vilkårsvurderinger,
     )
@@ -73,6 +77,8 @@ data class ArenaVedtakMedDetaljer(
     val rettighetkode: String,
     val rettighetnavn: String,
     val utfallkode: String?,
+    val saksbehandler: String?,
+    val beslutter: String?,
     val fakta: List<ArenaVedtakfakta>,
     val vilkårsvurderinger: List<ArenaVilkårsvurdering> = emptyList(),
 )

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -47,6 +47,8 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
             rettighetkode = "AAP",
             rettighetnavn = "Arbeidsavklaringspenger",
             utfallkode = "JA",
+            saksbehandler = null,
+            beslutter = null,
         )
 
         val alleVedtak = vedtakRepository.hentVedtakForSak(1)

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -47,6 +47,7 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
             rettighetkode = "AAP",
             rettighetnavn = "Arbeidsavklaringspenger",
             utfallkode = "JA",
+            begrunnelse = null,
             saksbehandler = null,
             beslutter = null,
         )


### PR DESCRIPTION
Henter BRUKERID_ANSVARLIG, BRUKERID_BESLUTTER og BEGRUNNELSE fra vedtak-tabellen og eksponerer dem i responsen.