### PR TITLE
Legg til relatertVedtak på vedtak i sak-detaljert-respons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,21 @@ back the input identifier as the only FOLKEREGISTERIDENT.
 
 ---
 
+## After making code changes
+
+After completing any code change, always run the full test suite and fix all failures before
+presenting the work as done:
+
+```
+./gradlew :app:test
+```
+
+This applies to every change — including small, seemingly safe edits — because adding or
+renaming fields often breaks existing test assertions or causes compilation errors in tests.
+Do not consider a task finished until the build and all tests pass.
+
+---
+
 ## Git workflow
 
 Before committing, always:

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/ArenaDatasource.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/ArenaDatasource.kt
@@ -45,6 +45,9 @@ fun <T : Any> ResultSet.map(block: (ResultSet) -> T): List<T> =
         while (next()) yield(block(this@map))
     }.toList()
 
+// getInt returnerer 0 for NULL-kolonner, så vi bruker getObject for å bevare null-verdier
+fun ResultSet.getIntOrNull(columnLabel: String): Int? = getObject(columnLabel) as? Int
+
 fun Connection.createParameterizedQuery(queryString: String): PreparedStatement {
     val query = prepareStatement(queryString)
     query.queryTimeout = 300 // set a timeout in seconds, to avoid long running queries

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -101,7 +101,7 @@ class VedtakRepository(private val dataSource: DataSource) {
         private val selectVedtakForSak = """
         SELECT v.vedtak_id, v.lopenrvedtak, v.vedtakstatuskode, vs.vedtakstatusnavn, v.vedtaktypekode, vt.vedtaktypenavn,
                v.fra_dato, v.til_dato, v.rettighetkode, rt.rettighetnavn, v.utfallkode, v.begrunnelse,
-               v.brukerid_ansvarlig, v.brukerid_beslutter,
+               v.brukerid_ansvarlig, v.brukerid_beslutter, v.vedtak_id_relatert,
                a.aktfasekode, a.aktfasenavn
           FROM vedtak v
           LEFT JOIN vedtaktype vt ON vt.vedtaktypekode = v.vedtaktypekode
@@ -137,6 +137,7 @@ class VedtakRepository(private val dataSource: DataSource) {
             begrunnelse = row.getString("begrunnelse"),
             saksbehandler = row.getString("brukerid_ansvarlig"),
             beslutter = row.getString("brukerid_beslutter"),
+            relatertVedtak = row.getObject("vedtak_id_relatert") as? Int,
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -137,7 +137,7 @@ class VedtakRepository(private val dataSource: DataSource) {
             begrunnelse = row.getString("begrunnelse"),
             saksbehandler = row.getString("brukerid_ansvarlig"),
             beslutter = row.getString("brukerid_beslutter"),
-            relatertVedtak = row.getObject("vedtak_id_relatert") as? Int,
+            relatertVedtak = row.getIntOrNull("vedtak_id_relatert"),
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -39,6 +39,7 @@ data class ArenaVedtakRad(
     val begrunnelse: String?,
     val saksbehandler: String?,
     val beslutter: String?,
+    val relatertVedtak: Int?,
 ) {
     fun medFakta(
         fakta: List<ArenaVedtakfakta>,
@@ -60,6 +61,7 @@ data class ArenaVedtakRad(
         begrunnelse = begrunnelse,
         saksbehandler = saksbehandler,
         beslutter = beslutter,
+        relatertVedtak = relatertVedtak,
         fakta = fakta,
         vilkårsvurderinger = vilkårsvurderinger,
     )
@@ -82,6 +84,7 @@ data class ArenaVedtakMedDetaljer(
     val begrunnelse: String?,
     val saksbehandler: String?,
     val beslutter: String?,
+    val relatertVedtak: Int?,
     val fakta: List<ArenaVedtakfakta>,
     val vilkårsvurderinger: List<ArenaVilkårsvurdering> = emptyList(),
 )

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -50,6 +50,7 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
             begrunnelse = null,
             saksbehandler = null,
             beslutter = null,
+            relatertVedtak = null,
         )
 
         val alleVedtak = vedtakRepository.hentVedtakForSak(1)


### PR DESCRIPTION
Eksponerer feltet VEDTAK_ID_RELATERT fra databasen som relatertVedtak på vedtak i GET /api/intern/sak/{sakid}/detaljert, slik at konsumenter kan vite hvilken vedtak et endringsvedtak har endret, og vise hva de faktiske endringene i endringsvedtaket er.