### PR TITLE
Legg til statuskode og statusnavn på saker hentet for person

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -18,10 +18,10 @@ class SakRepository(private val dataSource: DataSource) {
     }
 
 
-    fun hentSakerForPersnNummere(fodselsnumre: Set<String>): List<ArenaSakOppsummering> {
-        if (fodselsnumre.isEmpty()) return emptyList()
+    fun hentSakerForPerson(personidentifikatorerForPerson: Set<String>): List<ArenaSakOppsummering> {
+        if (personidentifikatorerForPerson.isEmpty()) return emptyList()
         return dataSource.connection.use { con ->
-            selectSakerForPersoner(fodselsnumre, con)
+            selectSakerForPersoner(personidentifikatorerForPerson, con)
         }
     }
 
@@ -82,6 +82,8 @@ class SakRepository(private val dataSource: DataSource) {
             sakstype = row.getString("sakstypenavn"),
             regDato = row.getDate("reg_dato").toLocalDate(),
             avsluttetDato = row.getDate("dato_avsluttet")?.toLocalDate(),
+            statusnavn = row.getString("sakstatusnavn"),
+            statuskode = row.getString("sakstatuskode"),
         )
 
         @Language("OracleSql")
@@ -97,13 +99,15 @@ class SakRepository(private val dataSource: DataSource) {
         @Language("OracleSql")
         internal val selectSakerMedAntallVedtakForFnrListe = """
             SELECT sak.sak_id, sak.aar, sak.lopenrsak, sakstype.sakstypenavn, sak.reg_dato, sak.dato_avsluttet,
-                COUNT(vedtak.vedtak_id) AS antall_vedtak
+                sak.sakstatuskode, sakstatus.sakstatusnavn, COUNT(vedtak.vedtak_id) AS antall_vedtak
             FROM SAK
             JOIN person ON person.person_id = sak.objekt_id
             JOIN sakstype ON sakstype.sakskode = sak.sakskode
+            LEFT JOIN sakstatus ON sak.sakstatuskode = sakstatus.sakstatuskode
             LEFT JOIN vedtak ON vedtak.sak_id = sak.sak_id
             WHERE person.fodselsnr IN ($FNR_LISTE_TOKEN) AND sak.tabellnavnalias = 'PERS'
-            GROUP BY sak.sak_id, sak.aar, sak.lopenrsak, sakstype.sakstypenavn, sak.reg_dato, sak.dato_avsluttet
+            GROUP BY sak.sak_id, sak.aar, sak.lopenrsak, sakstype.sakstypenavn, sak.reg_dato, sak.dato_avsluttet,
+                sak.sakstatuskode, sakstatus.sakstatusnavn
         """.trimIndent()
     }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
@@ -11,6 +11,8 @@ data class ArenaSakOppsummering(
     val aar: Int,
     val antallVedtak: Int,
     val sakstype: String?,
+    val statuskode: String,
+    val statusnavn: String,
     val regDato: LocalDate,
     val avsluttetDato: LocalDate?,
 ) {
@@ -22,6 +24,8 @@ data class ArenaSakOppsummering(
         sakstype = sakstype,
         regDato = regDato,
         avsluttetDato = avsluttetDato,
+        statuskode = statuskode,
+        statusnavn = statusnavn,
     )
 }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
@@ -17,10 +17,10 @@ class SakService(private val sakRepository: SakRepository) {
         CaffeineCacheMetrics.monitor(prometheus, sakerCache, "arenaoppslag_saker_per_person")
     }
 
-    fun hentSakerForPerson(fodselsnumre: Set<String>): SakerResponse {
-        val cacheNokkel = fodselsnumre.sorted().joinToString(",")
+    fun hentSakerForPerson(personidentifikatorer: Set<String>): SakerResponse {
+        val cacheNokkel = personidentifikatorer.sorted().joinToString(",")
         return sakerCache.get(cacheNokkel) {
-            val saker: List<ArenaSakOppsummering> = sakRepository.hentSakerForPersnNummere(fodselsnumre)
+            val saker: List<ArenaSakOppsummering> = sakRepository.hentSakerForPerson(personidentifikatorer)
             SakerResponse(saker = saker.map { it.tilKontrakt() })
         }
     }

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/SakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/SakRepositoryTest.kt
@@ -45,18 +45,20 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
             aar = 2021,
             antallVedtak = 1,
             sakstype = "Arbeidsavklaringspenger",
+            statuskode = "INAKT",
+            statusnavn = "Inaktiv",
             regDato = LocalDate.of(2022, 2, 2),
             avsluttetDato = null,
         )
         val sakRepository = SakRepository(h2)
-        val saker = sakRepository.hentSakerForPersnNummere(setOf("123"))
+        val saker = sakRepository.hentSakerForPerson(setOf("123"))
         assertThat(saker).containsExactly(forventetSak)
     }
 
     @Test
     fun `hentSakerForPersnNummere returnerer tom liste for ukjent person`() {
         val sakRepository = SakRepository(h2)
-        val saker = sakRepository.hentSakerForPersnNummere(setOf("007"))
+        val saker = sakRepository.hentSakerForPerson(setOf("007"))
         assertThat(saker).isEmpty()
     }
 
@@ -64,7 +66,7 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
     fun `hentSakerForPersnNummere returnerer tom liste for person uten saker`() {
         // Person "ingenvedtak" (person_id=3) er registrert uten noen saker
         val sakRepository = SakRepository(h2)
-        val saker = sakRepository.hentSakerForPersnNummere(setOf("ingenvedtak"))
+        val saker = sakRepository.hentSakerForPerson(setOf("ingenvedtak"))
         assertThat(saker).isEmpty()
     }
 
@@ -77,6 +79,8 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
                 aar = 2020,
                 antallVedtak = 2,
                 sakstype = "Arbeidsavklaringspenger",
+                statuskode = "INAKT",
+                statusnavn = "Inaktiv",
                 regDato = LocalDate.of(2020, 1, 15),
                 avsluttetDato = null,
             ),
@@ -86,19 +90,21 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
                 aar = 2023,
                 antallVedtak = 1,
                 sakstype = "Arbeidsavklaringspenger",
+                statuskode = "INAKT",
+                statusnavn = "Inaktiv",
                 regDato = LocalDate.of(2023, 3, 1),
                 avsluttetDato = LocalDate.of(2023, 12, 31),
             ),
         )
         val sakRepository = SakRepository(h2)
-        val saker = sakRepository.hentSakerForPersnNummere(setOf("tosaker"))
+        val saker = sakRepository.hentSakerForPerson(setOf("tosaker"))
         assertThat(saker).containsExactlyInAnyOrderElementsOf(forventedeSaker)
     }
 
     @Test
     fun `hentSakerForPersnNummere returnerer saker for flere personer i ett kall`() {
         val sakRepository = SakRepository(h2)
-        val saker = sakRepository.hentSakerForPersnNummere(setOf("123", "tosaker"))
+        val saker = sakRepository.hentSakerForPerson(setOf("123", "tosaker"))
         // "123" har 1 sak, "tosaker" har 2 saker - totalt 3 saker
         assertThat(saker).hasSize(3)
         assertThat(saker.map { it.sakId }).containsExactlyInAnyOrder("1", "901", "902")
@@ -107,7 +113,7 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
     @Test
     fun `hentSakerForPersnNummere returnerer tom liste naar settet er tomt`() {
         val sakRepository = SakRepository(h2)
-        val saker = sakRepository.hentSakerForPersnNummere(emptySet())
+        val saker = sakRepository.hentSakerForPerson(emptySet())
         assertThat(saker).isEmpty()
     }
 }

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakerResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakerResponse.kt
@@ -15,6 +15,8 @@ public data class ArenaSakOppsummeringKontrakt(
     val lopenummer: Int,
     val aar: Int,
     val antallVedtak: Int,
+    val statuskode: String,
+    val statusnavn: String,
     val sakstype: String?,
     val regDato: LocalDate,
     val avsluttetDato: LocalDate?,


### PR DESCRIPTION
Legger til `statuskode` og `statusnavn` på `ArenaSakOppsummering` og
`ArenaSakOppsummeringKontrakt`, slik at konsumenter av `/api/v1/person/saker`
får med saksstatus i responsen.