### PR TITLE
Endrer til å hente telleverk for person basert på personId

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -16,8 +16,10 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.TellerRequest
 import no.nav.aap.arenaoppslag.modeller.ArenaSakDetaljertRespons
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.service.HistorikkService
 import no.nav.aap.arenaoppslag.service.PosteringService
+import no.nav.aap.arenaoppslag.service.PersonService
 import no.nav.aap.arenaoppslag.service.SakService
 import no.nav.aap.arenaoppslag.service.TelleverkService
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
@@ -84,8 +86,7 @@ fun Route.sak(sakOgVedtakService: SakOgVedtakService, telleverkService: Tellever
         when (val sak = sakOgVedtakService.hentSakMedVedtak(sakid)) {
             null -> call.respond(status = HttpStatusCode.NotFound, message = "Fant ikke sak")
             else -> {
-                val fodselsnr = sak.person.fodselsnummer
-                val telleverk = telleverkService.hentTelleverkPåPerson(fodselsnr)
+                val telleverk  = telleverkService.hentTelleverkPåPerson(PersonId(sak.person.personId))
                 val response = ArenaSakDetaljertRespons.fromDomain(sak, telleverk)
 
                 call.respond(status = HttpStatusCode.OK, message = response)
@@ -95,20 +96,18 @@ fun Route.sak(sakOgVedtakService: SakOgVedtakService, telleverkService: Tellever
     }
 }
 
-fun Route.telleverk(telleverkService: TelleverkService, pdlGateway: IPdlGateway) {
+fun Route.telleverk(telleverkService: TelleverkService, personService: PersonService) {
     post("/telleverk") {
         logger.info("Henter telleverk")
         val request: TellerRequest = call.receive()
-        val fodselsnummer = request.personidentifikator
 
-        //TODO BRUK PDL for å finne andre personidentifikatorer knyttet til samme person
-        val alleIdenterForPerson = pdlGateway.hentAlleIdenterForPerson(fodselsnummer)
+        val personId = personService.hentPersonId(request.personidentifikator)
+            ?: return@post call.respond(HttpStatusCode.InternalServerError, "Noe gikk galt ved henting av telleverk for person")
 
-        when (val telleverk = telleverkService.hentTelleverkPåPerson(fodselsnummer)) {
+        when (val telleverk = telleverkService.hentTelleverkPåPerson(personId)) {
             null -> call.respond(status = HttpStatusCode.NotFound, message = "Fant ikke telleverk for person")
             else -> call.respond(status = HttpStatusCode.OK, message = telleverk)
         }
-
     }
 }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -32,6 +32,7 @@ import no.nav.aap.arenaoppslag.plugins.bruker
 import no.nav.aap.arenaoppslag.plugins.statusPages
 import no.nav.aap.arenaoppslag.service.HistorikkService
 import no.nav.aap.arenaoppslag.service.InternService
+import no.nav.aap.arenaoppslag.service.PersonService
 import no.nav.aap.arenaoppslag.service.PosteringService
 import no.nav.aap.arenaoppslag.service.SakService
 import no.nav.aap.arenaoppslag.service.TelleverkService
@@ -96,10 +97,12 @@ fun Application.server(
     val historikkService = skapHistorikkService(datasource)
     val sakService = skapSakervice(datasource)
     val telleverkService = skapTelleverkService(datasource)
+    val personService = skapPersonService(datasource, pdlGateway)
     val sakListeService = skapSakListeService(datasource)
     val utbetalingService = skapUtbetalingService(datasource)
-    routes(internService, historikkService, sakService, telleverkService, sakListeService, pdlGateway,
-        utbetalingService)
+
+    routes(internService, historikkService, sakService, telleverkService, sakListeService,
+        pdlGateway, personService, utbetalingService)
     databaseConnectionWarmup(historikkService)
 
     monitor.subscribe(ApplicationStarted) { environment ->
@@ -143,8 +146,6 @@ private fun skapInternService(datasource: DataSource): InternService {
     val periodeRepository = PeriodeRepository(datasource)
     val maksimumRepository = MaksimumRepository(datasource)
     val vedtakRepository = VedtakRepository(datasource)
-    val telleverkRepository = TelleverkRepository(datasource)
-    val personRepository = PersonRepository(datasource)
 
     return InternService(maksimumRepository, periodeRepository, vedtakRepository)
 }
@@ -179,6 +180,11 @@ private fun skapUtbetalingService(datasource: DataSource): PosteringService {
     return PosteringService(posteringRepository)
 }
 
+private fun skapPersonService(datasource: DataSource, pdlGateway: IPdlGateway): PersonService {
+    val personRepository = PersonRepository(datasource)
+    return PersonService(personRepository, pdlGateway)
+}
+
 private fun Application.routes(
     internService: InternService,
     historikkService: HistorikkService,
@@ -186,7 +192,9 @@ private fun Application.routes(
     telleverkService: TelleverkService,
     sakService: SakService,
     pdlGateway: IPdlGateway,
+    personService: PersonService,
     utbetalingService: PosteringService
+
 ) {
     routing {
         actuator(prometheus)
@@ -202,7 +210,7 @@ private fun Application.routes(
             route("/api/v1") {
                 // Eksterne APIer som kan brukes av andre. Brekkende endringer vil enten varsles eller versjoneres
                 historikk(historikkService)
-                telleverk(telleverkService, pdlGateway)
+                telleverk(telleverkService, personService)
                 sakerForPerson(sakService, pdlGateway)
                 maksdato(sakService)
                 utbetalinger(utbetalingService)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/PersonRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/PersonRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.arenaoppslag.database
 
 import no.nav.aap.arenaoppslag.kontrakt.intern.Person
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.TestOnly
 import org.slf4j.Logger
@@ -11,9 +12,9 @@ import javax.sql.DataSource
 
 class PersonRepository(private val dataSource: DataSource) {
 
-    fun hentPersonIdHvisEksisterer(fodselnummerene: Set<String>): Int? {
+    fun hentPersonIdHvisEksisterer(fodselnummerene: Set<String>): PersonId? {
         dataSource.connection.use { con ->
-            return selectPersonIdFraFnr(fodselnummerene, con)
+            return selectPersonIdFraFnr(fodselnummerene, con)?.let { PersonId(it) }
         }
     }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/TelleverkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/TelleverkRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.arenaoppslag.database;
 
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.intellij.lang.annotations.Language
 import javax.sql.DataSource;
 
@@ -14,17 +15,16 @@ class TelleverkRepository(private val datasource: DataSource) {
         internal val selectTelleverkPåPerson = """
             SELECT b.verdi, b.beregningsleddkode
             FROM BEREGNINGSLEDD b
-            JOIN PERSON p ON p.person_id = b.person_id
             WHERE b.tabellnavnalias_kilde = 'KVOTBR'
-              AND p.fodselsnr = ?
+              AND b.person_id = ?
               AND b.beregningsleddkode IN ('AAP', 'MAAPU')
         """.trimIndent()
     }
 
-    fun hentTelleverkPåPerson(fodselsnr: String): Set<KvoteVerdi> {
+    fun hentTelleverkPåPerson(personId: PersonId): Set<KvoteVerdi> {
         return datasource.connection.use { con ->
             con.prepareStatement(selectTelleverkPåPerson).use { preparedStatement ->
-                preparedStatement.setString(1, fodselsnr)
+                preparedStatement.setInt(1, personId.id)
                 val resultSet = preparedStatement.executeQuery()
                 resultSet.map { row ->
                     KvoteVerdi(
@@ -36,4 +36,3 @@ class TelleverkRepository(private val datasource: DataSource) {
         }
     }
 }
-

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/PersonId.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/PersonId.kt
@@ -1,0 +1,3 @@
+package no.nav.aap.arenaoppslag.modeller
+
+data class PersonId(val id: Int)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/HistorikkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/HistorikkService.kt
@@ -80,8 +80,8 @@ class HistorikkService(
         return fodselsnummerene.firstNotNullOfOrNull { personIdCache.getIfPresent(it) }
             ?: personRepository.hentPersonIdHvisEksisterer(fodselsnummerene)
                 ?.also { funnetPersonId ->
-                    fodselsnummerene.forEach { personIdCache.put(it, funnetPersonId) }
-                }
+                    fodselsnummerene.forEach { personIdCache.put(it, funnetPersonId.id) }
+                }?.id
     }
 
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/PersonService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/PersonService.kt
@@ -1,0 +1,17 @@
+package no.nav.aap.arenaoppslag.service
+
+import no.nav.aap.arenaoppslag.IPdlGateway
+import no.nav.aap.arenaoppslag.database.PersonRepository
+import no.nav.aap.arenaoppslag.modeller.PersonId
+
+class PersonService(
+    private val personRepository: PersonRepository,
+    private val pdlGateway: IPdlGateway,
+) {
+    fun hentPersonId(fodselsnummer: String): PersonId? {
+        val alleIdenter = pdlGateway.hentAlleIdenterForPerson(fodselsnummer)
+            .map { it.ident }
+            .toSet()
+        return personRepository.hentPersonIdHvisEksisterer(alleIdenter)
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
@@ -1,18 +1,17 @@
 package no.nav.aap.arenaoppslag.service
 
-
 import no.nav.aap.arenaoppslag.database.TelleverkRepository
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.TellerverkPåPerson
 
-class TelleverkService(private val telleverkRepository: TelleverkRepository)
-{
-        fun hentTelleverkPåPerson(fodselsnr: String): TellerverkPåPerson? {
-            val tellekvoter = telleverkRepository.hentTelleverkPåPerson(fodselsnr)
-            val ordinaerAAPKvote = tellekvoter.find { it.kode == "AAP" }?.verdi ?: return null
-            val utvidetAAPKvote = tellekvoter.find { it.kode == "MAAPU" }?.verdi ?: return null
-            return TellerverkPåPerson(
-                ordineerAAPKvote = ordinaerAAPKvote,
-                utvidetAAPKvote = utvidetAAPKvote
-            )
-        }
+class TelleverkService(private val telleverkRepository: TelleverkRepository) {
+    fun hentTelleverkPåPerson(personId: PersonId): TellerverkPåPerson? {
+        val tellekvoter = telleverkRepository.hentTelleverkPåPerson(personId)
+        val ordinaerAAPKvote = tellekvoter.find { it.kode == "AAP" }?.verdi ?: return null
+        val utvidetAAPKvote = tellekvoter.find { it.kode == "MAAPU" }?.verdi ?: return null
+        return TellerverkPåPerson(
+            ordineerAAPKvote = ordinaerAAPKvote,
+            utvidetAAPKvote = utvidetAAPKvote
+        )
+    }
 }

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/TelleverkRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/TelleverkRepositoryTest.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.arenaoppslag.database
 
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -12,7 +13,7 @@ class TelleverkRepositoryTest : H2TestBase("flyway/telleverk", "flyway/minimumte
 
         val telleverkRepository = TelleverkRepository(h2)
 
-        val kvote = telleverkRepository.hentTelleverkPåPerson("123")
+        val kvote = telleverkRepository.hentTelleverkPåPerson(PersonId(1))
 
         assertThat(kvote).hasSize(2)
         assertThat(kvote).isEqualTo(setOf(KvoteVerdi("AAP", 5280), KvoteVerdi("MAAPU", 460)))
@@ -22,7 +23,7 @@ class TelleverkRepositoryTest : H2TestBase("flyway/telleverk", "flyway/minimumte
     fun `hentTelleverkPåPerson returnerer tomt sett for ukjent person`() {
         val telleverkRepository = TelleverkRepository(h2)
 
-        val kvote = telleverkRepository.hentTelleverkPåPerson("000")
+        val kvote = telleverkRepository.hentTelleverkPåPerson(PersonId(999))
         assertThat(kvote).isEmpty()
     }
 
@@ -30,8 +31,8 @@ class TelleverkRepositoryTest : H2TestBase("flyway/telleverk", "flyway/minimumte
     fun `hentTelleverkPåPerson returnerer kun data for etterspurt person`() {
         val telleverkRepository = TelleverkRepository(h2)
 
-        val kvotePerson1 = telleverkRepository.hentTelleverkPåPerson("123")
-        val kvotePerson2 = telleverkRepository.hentTelleverkPåPerson("321")
+        val kvotePerson1 = telleverkRepository.hentTelleverkPåPerson(PersonId(1))
+        val kvotePerson2 = telleverkRepository.hentTelleverkPåPerson(PersonId(2))
 
         val aapPerson1 = kvotePerson1.find { it.kode == "AAP" }!!.verdi
         val aapPerson2 = kvotePerson2.find { it.kode == "AAP" }!!.verdi

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/HistorikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/HistorikkServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.verify
 import no.nav.aap.arenaoppslag.database.HistorikkRepository
 import no.nav.aap.arenaoppslag.database.PersonRepository
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -80,7 +81,7 @@ class HistorikkServiceTest {
         val personRepository = mockk<PersonRepository>()
         val historikkRepository = mockk<HistorikkRepository>() // brukes ikke
 
-        every { personRepository.hentPersonIdHvisEksisterer(finnes) } returns 1
+        every { personRepository.hentPersonIdHvisEksisterer(finnes) } returns PersonId(1)
         every { personRepository.hentPersonIdHvisEksisterer(finnesIkke) } returns null
 
         val service = HistorikkService(personRepository, historikkRepository)
@@ -99,7 +100,7 @@ class HistorikkServiceTest {
         val personRepository = mockk<PersonRepository>()
         val historikkRepository = mockk<HistorikkRepository>()
 
-        every { personRepository.hentPersonIdHvisEksisterer(any()) } returns 1
+        every { personRepository.hentPersonIdHvisEksisterer(any()) } returns PersonId(1)
 
         val service = HistorikkService(personRepository, historikkRepository)
 


### PR DESCRIPTION
Når vi hentet telleverk før tok vi inn et fødselsnummer og hentet televerk for dette fødselsnummeret. Dette kunne føre til en del feil fordi fødselsnummeret kan for en person endre seg over tid. Følgende implemntasjon er derfor gjort:

1. Får inn fødselsnummer
2. Henter alle personidentifikatorer fra PDL
3. Finner personId i Arena for listen over personidentifikatorer (hvis mer enn 1: Feilmelding)
4. Bruker denne personId-en videre i andre spørringer

Jeg må bare få endelig bekreftet at personId faktisk er en unik nøkkel i Arena som følger en person selv om de har flere fødselsummere eller dnummere.