### PR TITLE
Bruke PersonId for spørring etter saker for person

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -45,18 +45,15 @@ fun Route.historikk(historikkService: HistorikkService) {
     }
 }
 
-fun Route.sakerForPerson(sakService: SakService, pdlGateway: IPdlGateway) {
+fun Route.sakerForPerson(sakService: SakService, personService: PersonService) {
     post("/person/saker") {
         logger.info("Henter saker for person")
         val request: SakerRequestV1 = call.receive()
 
-        val alleIdenter = pdlGateway.hentAlleIdenterForPerson(request.personidentifikator)
-            .map { it.ident }
-            .toSet()
-            .also { require(it.isNotEmpty()) { "PDL returnerte ingen identer for person" } }
+        val personId = personService.hentPersonId(request.personidentifikator)
+            ?: return@post call.respond(HttpStatusCode.InternalServerError, "Noe gikk galt ved henting av saker for person")
 
-
-        val respons: SakerResponse = sakService.hentSakerForPerson(alleIdenter)
+        val respons: SakerResponse = sakService.hentSakerForPerson(personId)
 
         call.respond(HttpStatusCode.OK, respons)
     }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -102,7 +102,7 @@ fun Application.server(
     val utbetalingService = skapUtbetalingService(datasource)
 
     routes(internService, historikkService, sakService, telleverkService, sakListeService,
-        pdlGateway, personService, utbetalingService)
+        personService, utbetalingService)
     databaseConnectionWarmup(historikkService)
 
     monitor.subscribe(ApplicationStarted) { environment ->
@@ -191,10 +191,8 @@ private fun Application.routes(
     sakOgVedtakService: SakOgVedtakService,
     telleverkService: TelleverkService,
     sakService: SakService,
-    pdlGateway: IPdlGateway,
     personService: PersonService,
     utbetalingService: PosteringService
-
 ) {
     routing {
         actuator(prometheus)
@@ -211,7 +209,7 @@ private fun Application.routes(
                 // Eksterne APIer som kan brukes av andre. Brekkende endringer vil enten varsles eller versjoneres
                 historikk(historikkService)
                 telleverk(telleverkService, personService)
-                sakerForPerson(sakService, pdlGateway)
+                sakerForPerson(sakService, personService)
                 maksdato(sakService)
                 utbetalinger(utbetalingService)
             }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -4,6 +4,7 @@ import no.nav.aap.arenaoppslag.modeller.ArenaSak
 import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
 import no.nav.aap.arenaoppslag.modeller.ArenaSakPerson
 import no.nav.aap.arenaoppslag.modeller.Maksdatolinje
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.intellij.lang.annotations.Language
 import java.sql.Connection
 import java.sql.ResultSet
@@ -17,10 +18,9 @@ class SakRepository(private val dataSource: DataSource) {
         }
     }
 
-    fun hentSakerForPerson(personidentifikatorerForPerson: Set<String>): List<ArenaSakOppsummering> {
-        if (personidentifikatorerForPerson.isEmpty()) return emptyList()
+    fun hentSakerForPerson(personId: PersonId): List<ArenaSakOppsummering> {
         return dataSource.connection.use { con ->
-            selectSakerForPersoner(personidentifikatorerForPerson, con)
+            selectSakerForPersonId(personId, con)
         }
     }
 
@@ -32,7 +32,6 @@ class SakRepository(private val dataSource: DataSource) {
     }
 
     companion object {
-        private const val FNR_LISTE_TOKEN = "?:fodselsnummer"
         private const val SAK_LISTE_TOKEN = "?:sak_id"
 
         private fun selectSakerMedNyesteVedtakOgMaxdato(sakidliste: Set<Int>, connection: Connection): List<Maksdatolinje> {
@@ -60,16 +59,9 @@ class SakRepository(private val dataSource: DataSource) {
                 sakStatus = row.getString("sak_statuskode")
             )
 
-        private fun queryMedFodselsnummerListe(baseQuery: String, fodselsnumre: Set<String>): String {
-            // Oracle støtter ikke listeparametere i PreparedStatement, så vi interpolerer direkte
-            val allePersonensFodselsnummer = fodselsnumre.joinToString(separator = ",") { "'$it'" }
-            return baseQuery.replace(FNR_LISTE_TOKEN, allePersonensFodselsnummer)
-        }
-
-        fun selectSakerForPersoner(fodselsnumre: Set<String>, connection: Connection): List<ArenaSakOppsummering> {
-            val query = queryMedFodselsnummerListe(selectSakerMedAntallVedtakForFnrListe, fodselsnumre)
-            // Er i teorien unsafe, men data kommer fra PDL så SQL injection risken er lav
-            connection.prepareStatement(query).use { preparedStatement ->
+        fun selectSakerForPersonId(personId: PersonId, connection: Connection): List<ArenaSakOppsummering> {
+            connection.prepareStatement(selectSakerMedAntallVedtakForPersonId).use { preparedStatement ->
+                preparedStatement.setInt(1, personId.id)
                 val resultSet = preparedStatement.executeQuery()
                 return resultSet.map { row -> mapperForArenaSakKontrakt(row) }
             }
@@ -128,16 +120,15 @@ class SakRepository(private val dataSource: DataSource) {
         """.trimIndent()
 
         @Language("OracleSql")
-        internal val selectSakerMedAntallVedtakForFnrListe = """
+        internal val selectSakerMedAntallVedtakForPersonId = """
             SELECT sak.sak_id, sak.aar, sak.lopenrsak, sakstype.sakstypenavn, sak.reg_dato, sak.dato_avsluttet,
                 sak.sakstatuskode, sakstatus.sakstatusnavn, COUNT(vedtak.vedtak_id) AS antall_vedtak
             FROM SAK
-            JOIN person ON person.person_id = sak.objekt_id
             JOIN sakstype ON sakstype.sakskode = sak.sakskode
             LEFT JOIN sakstatus ON sak.sakstatuskode = sakstatus.sakstatuskode
             LEFT JOIN vedtak ON vedtak.sak_id = sak.sak_id
                 AND (vedtak.fra_dato <= vedtak.til_dato OR vedtak.til_dato IS NULL)
-            WHERE person.fodselsnr IN ($FNR_LISTE_TOKEN) AND sak.tabellnavnalias = 'PERS'
+            WHERE sak.objekt_id = ? AND sak.tabellnavnalias = 'PERS'
             GROUP BY sak.sak_id, sak.aar, sak.lopenrsak, sakstype.sakstypenavn, sak.reg_dato, sak.dato_avsluttet,
                 sak.sakstatuskode, sakstatus.sakstatusnavn
         """.trimIndent()

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
@@ -8,11 +8,13 @@ import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
 import no.nav.aap.arenaoppslag.modeller.PersonId
+import java.util.concurrent.TimeUnit
 
 class SakService(private val sakRepository: SakRepository) {
 
     private val sakerCache = Caffeine.newBuilder()
         .maximumSize(10_000)
+        .expireAfterAccess(30, TimeUnit.MINUTES)
         .build<String, SakerResponse>()
 
     init {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
@@ -7,6 +7,7 @@ import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
+import no.nav.aap.arenaoppslag.modeller.PersonId
 
 class SakService(private val sakRepository: SakRepository) {
 
@@ -18,10 +19,10 @@ class SakService(private val sakRepository: SakRepository) {
         CaffeineCacheMetrics.monitor(prometheus, sakerCache, "arenaoppslag_saker_per_person")
     }
 
-    fun hentSakerForPerson(personidentifikatorer: Set<String>): SakerResponse {
-        val cacheNokkel = personidentifikatorer.sorted().joinToString(",")
+    fun hentSakerForPerson(personId: PersonId): SakerResponse {
+        val cacheNokkel = personId.id.toString()
         return sakerCache.get(cacheNokkel) {
-            val saker: List<ArenaSakOppsummering> = sakRepository.hentSakerForPerson(personidentifikatorer)
+            val saker: List<ArenaSakOppsummering> = sakRepository.hentSakerForPerson(personId)
             SakerResponse(saker = saker.map { it.tilKontrakt() })
         }
     }

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/SakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/SakRepositoryTest.kt
@@ -4,6 +4,7 @@ import no.nav.aap.arenaoppslag.modeller.ArenaSak
 import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
 import no.nav.aap.arenaoppslag.modeller.ArenaSakPerson
 import no.nav.aap.arenaoppslag.modeller.Maksdatolinje
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,7 +47,7 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
     }
 
     @Test
-    fun `hentSakerForPersnNummere returnerer saker for en kjent person med én sak og ett vedtak`() {
+    fun `hentSakerForPerson returnerer saker for en kjent person med én sak og ett vedtak`() {
         val forventetSak = ArenaSakOppsummering(
             sakId = "1",
             lopenummer = 1,
@@ -58,25 +59,26 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
             regDato = LocalDate.of(2022, 2, 1),
             avsluttetDato = null,
         )
-        val saker = sakRepository.hentSakerForPerson(setOf("123"))
+        // person_id=1 tilsvarer fnr "123" i minimumtest-datasettet
+        val saker = sakRepository.hentSakerForPerson(PersonId(1))
         assertThat(saker).containsExactly(forventetSak)
     }
 
     @Test
-    fun `hentSakerForPersnNummere returnerer tom liste for ukjent person`() {
-        val saker = sakRepository.hentSakerForPerson(setOf("007"))
+    fun `hentSakerForPerson returnerer tom liste for ukjent person`() {
+        val saker = sakRepository.hentSakerForPerson(PersonId(99999))
         assertThat(saker).isEmpty()
     }
 
     @Test
-    fun `hentSakerForPersnNummere returnerer tom liste for person uten saker`() {
-        // Person "ingenvedtak" (person_id=3) er registrert uten noen saker
-        val saker = sakRepository.hentSakerForPerson(setOf("ingenvedtak"))
+    fun `hentSakerForPerson returnerer tom liste for person uten saker`() {
+        // Person "ingenvedtak" har person_id=3 i minimumtest-datasettet
+        val saker = sakRepository.hentSakerForPerson(PersonId(3))
         assertThat(saker).isEmpty()
     }
 
     @Test
-    fun `hentSakerForPersnNummere henter alle saker og teller vedtak per sak korrekt`() {
+    fun `hentSakerForPerson henter alle saker og teller vedtak per sak korrekt`() {
         val forventedeSaker = listOf(
             ArenaSakOppsummering(
                 sakId = "901",
@@ -101,22 +103,9 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
                 avsluttetDato = LocalDate.of(2023, 12, 31),
             ),
         )
-        val saker = sakRepository.hentSakerForPerson(setOf("tosaker"))
+        // person_id=900 tilsvarer fnr "tosaker" i saklistetest-datasettet
+        val saker = sakRepository.hentSakerForPerson(PersonId(900))
         assertThat(saker).containsExactlyInAnyOrderElementsOf(forventedeSaker)
-    }
-
-    @Test
-    fun `hentSakerForPersnNummere returnerer saker for flere personer i ett kall`() {
-        val saker = sakRepository.hentSakerForPerson(setOf("123", "tosaker"))
-        // "123" har 1 sak, "tosaker" har 2 saker - totalt 3 saker
-        assertThat(saker).hasSize(3)
-        assertThat(saker.map { it.sakId }).containsExactlyInAnyOrder("1", "901", "902")
-    }
-
-    @Test
-    fun `hentSakerForPersnNummere returnerer tom liste naar settet er tomt`() {
-        val saker = sakRepository.hentSakerForPerson(emptySet())
-        assertThat(saker).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
Skriver om slik at vi bruker PersonId også på spørringer for saker for person på samme måte som man gjør for telleverk (innført i egen PR). Legger også på en expiry på saker for person sin cache.