### PR TITLE
ordineerAAPKvote kan være null i enkelte tilfeller

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -106,6 +106,7 @@ fun Route.telleverk(telleverkService: TelleverkService, personService: PersonSer
             ?: return@post call.respond(HttpStatusCode.NotFound, "Fant ikke personen i Arena")
 
         val telleverk = telleverkService.hentTelleverkForPerson(personId)
+            ?: return@post call.respond(HttpStatusCode.NotFound, "Fant ikke telleverk for personen i Arena")
         call.respond(status = HttpStatusCode.OK, message = telleverk)
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
@@ -7,7 +7,7 @@ import no.nav.aap.arenaoppslag.modeller.TelleverkForPerson
 class TelleverkService(private val telleverkRepository: TelleverkRepository) {
     fun hentTelleverkForPerson(personId: PersonId): TelleverkForPerson {
         val tellekvoter = telleverkRepository.hentTelleverkForPerson(personId)
-        val ordinaerAAPKvote = tellekvoter.first { it.kode == "AAP" }.verdi // skal alltid finnes i Arena
+        val ordinaerAAPKvote = tellekvoter.firstOrNull { it.kode == "AAP" }.verdi // skal alltid finnes i Arena
         val utvidetAAPKvote = tellekvoter.firstOrNull { it.kode == "MAAPU" }?.verdi
         return TelleverkForPerson(
             ordineerAAPKvote = ordinaerAAPKvote,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
@@ -5,10 +5,17 @@ import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.TelleverkForPerson
 
 class TelleverkService(private val telleverkRepository: TelleverkRepository) {
-    fun hentTelleverkForPerson(personId: PersonId): TelleverkForPerson {
+    fun hentTelleverkForPerson(personId: PersonId): TelleverkForPerson? {
         val tellekvoter = telleverkRepository.hentTelleverkForPerson(personId)
-        val ordinaerAAPKvote = tellekvoter.firstOrNull { it.kode == "AAP" }.verdi // skal alltid finnes i Arena
+        val ordinaerAAPKvote = tellekvoter.firstOrNull { it.kode == "AAP" }?.verdi
         val utvidetAAPKvote = tellekvoter.firstOrNull { it.kode == "MAAPU" }?.verdi
+
+        // ordinaerAAPKvote skal finnes i alle tilfeller. Men det er enkelte unntak for hvis personen ikke har
+        // telleverk i det hele tatt. F.eks. fordi det ikke er fattet noen vedtak på saken til personen.
+        if (ordinaerAAPKvote == null) {
+            return null
+        }
+
         return TelleverkForPerson(
             ordineerAAPKvote = ordinaerAAPKvote,
             utvidetAAPKvote = utvidetAAPKvote


### PR DESCRIPTION
ordineerAAPKvote på telleverk kan i enkelte tilfeller være null, gjør derfor feltet nullable og bruker `firstOrNull` tilsvarende den andre kvoten på telleverket.