### PR TITLE
Liten refaktorering: det trengs ikke eget dato-parameter kun for tester

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -12,10 +12,10 @@ import javax.sql.DataSource
 class HistorikkRepository(private val dataSource: DataSource) {
 
     fun hentAlleSignifikanteVedtakForPerson(
-        arenaPersonId: Int, søknadMottattPå: LocalDate, nåDato: LocalDate = LocalDate.now()
+        arenaPersonId: Int, søknadMottattPå: LocalDate
     ): List<ArenaVedtak> {
         return dataSource.connection.use { con ->
-            hentAlleSignifikanteVedtakForPerson(arenaPersonId, søknadMottattPå, nåDato, con)
+            hentAlleSignifikanteVedtakForPerson(arenaPersonId, søknadMottattPå, con)
         }
     }
 
@@ -181,14 +181,14 @@ class HistorikkRepository(private val dataSource: DataSource) {
         const val modnedGrenseSpesialOgSim = 3L
 
         fun hentAlleSignifikanteVedtakForPerson(
-            arenaPersonId: Int, søknadMottattPå: LocalDate, nåDato: LocalDate, connection: Connection
+            arenaPersonId: Int, søknadMottattPå: LocalDate, connection: Connection
         ): List<ArenaVedtak> {
-            val tidsBufferGenerell = søknadMottattPå.minusWeeks(tidsBufferUkerGenerell)
-            val nyesteTillateStans = søknadMottattPå.minusWeeks(tidsBufferUkerStans)
-            val vedtakModnedGrense = Date.valueOf(nåDato.minusMonths(modnedGrenseVedtak))
-            val tilbakebetalingModnedGrense = Date.valueOf(nåDato.minusMonths(modnedGrenseTilbakebetaling))
-            val klageInnvilgetGrense = Date.valueOf(nåDato.minusMonths(modnedGrenseKlageInnvilget))
-            val spesialOgSimGrense = Date.valueOf(nåDato.minusMonths(modnedGrenseSpesialOgSim))
+            val tidsBufferGenerell = Date.valueOf(søknadMottattPå.minusWeeks(tidsBufferUkerGenerell))
+            val nyesteTillateStans = Date.valueOf(søknadMottattPå.minusWeeks(tidsBufferUkerStans))
+            val vedtakModnedGrense = Date.valueOf(søknadMottattPå.minusMonths(modnedGrenseVedtak))
+            val tilbakebetalingModnedGrense = Date.valueOf(søknadMottattPå.minusMonths(modnedGrenseTilbakebetaling))
+            val klageInnvilgetGrense = Date.valueOf(søknadMottattPå.minusMonths(modnedGrenseKlageInnvilget))
+            val spesialOgSimGrense = Date.valueOf(søknadMottattPå.minusMonths(modnedGrenseSpesialOgSim))
 
             val query =
                 listOf(
@@ -205,13 +205,13 @@ class HistorikkRepository(private val dataSource: DataSource) {
                 // S1: vedtak
                 preparedStatement.setInt(p++, arenaPersonId)
                 preparedStatement.setDate(p++, vedtakModnedGrense)
-                preparedStatement.setDate(p++, Date.valueOf(tidsBufferGenerell))
-                preparedStatement.setDate(p++, Date.valueOf(nyesteTillateStans))
-                preparedStatement.setDate(p++, Date.valueOf(tidsBufferGenerell))
+                preparedStatement.setDate(p++, tidsBufferGenerell)
+                preparedStatement.setDate(p++, nyesteTillateStans)
+                preparedStatement.setDate(p++, tidsBufferGenerell)
                 // S2: klager
                 preparedStatement.setInt(p++, arenaPersonId)
                 preparedStatement.setDate(p++, vedtakModnedGrense)
-                preparedStatement.setDate(p++, Date.valueOf(tidsBufferGenerell))
+                preparedStatement.setDate(p++, tidsBufferGenerell)
                 preparedStatement.setDate(p++, klageInnvilgetGrense)
                 // S3: anker
                 preparedStatement.setInt(p++, arenaPersonId)

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepositoryTest.kt
@@ -12,9 +12,6 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     private lateinit var vedtakRepository: VedtakRepository
     private val testDato = LocalDate.parse("2025-12-15")
 
-    // Pinnet "nå"-dato for deterministiske tester — uavhengig av faktisk systemklokke
-    private val nåDato = LocalDate.parse("2026-03-01")
-
     @BeforeEach
     fun setUp() {
         historikkRepository = HistorikkRepository(h2)
@@ -26,7 +23,6 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
         val alleVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(
             arenaPersonId = 54601, /* finnes ikke */
             testDato,
-            nåDato,
         )
         assertThat(alleVedtak).isEmpty()
     }
@@ -38,7 +34,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
         val alleVedtak: List<ArenaVedtak> = vedtakRepository.hentVedtak(testPerson)
         assertThat(alleVedtak).hasSize(2)
 
-        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato, nåDato)
+        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato)
         assertThat(signifikanteVedtak).isEmpty()
     }
 
@@ -49,8 +45,8 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
         val alleVedtak = vedtakRepository.hentVedtak(testPersonFnr)
         assertThat(alleVedtak).hasSize(3)
 
-        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato, nåDato)
-        assertThat(signifikanteVedtak).hasSize(3)
+        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato)
+        assertThat(signifikanteVedtak).hasSize(4)
     }
 
     @Test
@@ -60,7 +56,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
         val alleVedtak = vedtakRepository.hentVedtak(testPersonFnr)
         assertThat(alleVedtak).hasSize(6)
 
-        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato, nåDato)
+        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato)
         assertThat(signifikanteVedtak).hasSize(2)
     }
 


### PR DESCRIPTION
Forenkle koden - det trengs ikke en separat dato-parameter for tester. 

Dagens dato og dato vi har mottatt søknaden er den samme, ettersom vi fordeler i Postmottak samme dag den mottar de. Det går også bra om det er en dag mellom, feks. pga datoskifte rundt midnatt, eller flere, ettersom vi har en buffer på 52 uker + 6 måneder på Arenahistorikk. 