### PR TITLE
fix: unngå sjelden situasjon som forvirrer

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -51,7 +51,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
                   OR
                 (vedtaktypekode = 'S' AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
-          AND NOT (utfallkode = 'NEI' AND til_dato IS NULL AND fra_dato <= ?) -- utfallkode NEI vil ha åpen til_dato, så ekskluder disse når de er gamle 
+          AND NOT (utfallkode = 'NEI' AND til_dato IS NULL AND (fra_dato IS NOT NULL AND fra_dato <= ?)) -- utfallkode NEI vil ha åpen til_dato, så ekskluder disse når de er gamle 
         """.trimIndent()
 
         // S2: Hent alle AAP-klager med relevant historikk for personen

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepositoryTest.kt
@@ -61,14 +61,14 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     }
 
     @Test
-    fun `Ingen signifikante vedtak for person uten påbegynte vedtak`() {
+    fun `Signifikante vedtak for person med AA115 som ikke er påbegynt`() {
         val testPersonFnr = "426282"
         val testPersonId = 426282
         val alleVedtak = vedtakRepository.hentVedtak(testPersonFnr)
         assertThat(alleVedtak).hasSize(1)
 
         val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(testPersonId, testDato)
-        assertThat(signifikanteVedtak).hasSize(0)
+        assertThat(signifikanteVedtak).hasSize(1)
     }
 
 }

--- a/app/src/test/resources/flyway/eksisterer/V1_6__insert_vedtak_historikk.sql
+++ b/app/src/test/resources/flyway/eksisterer/V1_6__insert_vedtak_historikk.sql
@@ -131,8 +131,7 @@ values (987, 'korrekt', 'Gammel', 'Rettighet', 'AKTIV'),
        (876, 'duplikat', 'Se f.nr korrekt', 'Må ikke brukes', 'DUPLIKAT_TIL_BEH');
 
 
-
--- Porten-sak: FAGSYSTEM-426282
+-- person med nyere vedtak som ikke har til og fra dato fordi det ikke er jobbet med
 insert into PERSON(PERSON_ID, FODSELSNR, ETTERNAVN, FORNAVN)
 values (426282, '426282', 'Buggeson', 'Test');
 Insert into SAK (SAK_ID, SAKSKODE, REG_DATO, REG_USER, MOD_DATO, MOD_USER, TABELLNAVNALIAS, OBJEKT_ID, AAR, LOPENRSAK,


### PR DESCRIPTION
Regn automatisk opprettet ikke-besluttet AA115-vedtak som signifikant historikk. 
Dette forekommer svært sjelden, men har skapt to Porten-saker, som er tidkrevende. 