### PR TITLE
Ikke filtrere bort vedtak med fra_dato > til_dato

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
@@ -218,7 +218,6 @@ class MaksimumRepository(
            AND rettighetkode = 'AAP'
            AND vedtaktypekode IN ('O', 'E', 'G', 'S')
            AND vedtakstatuskode IN ('IVERK', 'AVSLU')
-           AND (fra_dato <= til_dato OR til_dato IS NULL)
            AND (til_dato >= ? OR til_dato IS NULL) 
            AND fra_dato <= ?
     """.trimIndent()

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -123,7 +123,6 @@ class SakRepository(private val dataSource: DataSource) {
             JOIN sakstype ON sakstype.sakskode = sak.sakskode
             LEFT JOIN sakstatus ON sak.sakstatuskode = sakstatus.sakstatuskode
             LEFT JOIN vedtak ON vedtak.sak_id = sak.sak_id
-                AND (vedtak.fra_dato <= vedtak.til_dato OR vedtak.til_dato IS NULL)
             WHERE sak.objekt_id = ? AND sak.tabellnavnalias = 'PERS'
             GROUP BY sak.sak_id, sak.aar, sak.lopenrsak, sakstype.sakstypenavn, sak.reg_dato, sak.dato_avsluttet,
                 sak.sakstatuskode, sakstatus.sakstatusnavn

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -73,7 +73,6 @@ class VedtakRepository(private val dataSource: DataSource) {
                  WHERE fodselsnr = ?) 
            AND rettighetkode = 'AAP'
            AND vedtaktypekode IN ('O', 'E', 'G', 'S')
-           AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
         fun selectVedtakStatuser(fodselsnr: String, connection: Connection): List<VedtakStatus> {
@@ -106,7 +105,6 @@ class VedtakRepository(private val dataSource: DataSource) {
           LEFT JOIN aktivitetfase a ON a.aktfasekode = v.aktfasekode
           LEFT JOIN rettighettype rt ON rt.rettighetkode = v.rettighetkode
          WHERE sak_id = ?
-           AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
         private fun selectVedtakForSak(sakId: Int, connection: Connection): List<ArenaVedtakRad> {


### PR DESCRIPTION
Ikke filtrere bort vedtak med fra_dato > til_dato, flytt ansvaret til konsumenter. Gi komplett datasett.

Tanken er at endepunktene våre må returnere komplette datasett med alle gyldige vedtak. I dag filtreres en del bort fordi Kelvin sine Periode-objekter tryner om fradato > tildato. Men vi ønsker helle at ansvaret her ligger hos konsumentene som får håndtere det som faktisk er gyldige og reelle data. 

Pga en kjent mangel her i api-intern så må først api-intern skrives om til å støtte dette. Og så må det testes i dev før vi merker PR. 