### PR TITLE
Bugfix: fikse duplikate utbetalinger på vedtak

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepository.kt
@@ -272,7 +272,7 @@ class MaksimumRepository(
              WHERE vedtak_id = ?) p
             ON m.meldekort_id = p.meldekort_id
         JOIN
-            MELDEKORTPERIODE mkp ON mkp.periodekode = m.periodekode
+            MELDEKORTPERIODE mkp ON mkp.periodekode = m.periodekode AND mkp.aar = m.aar
         WHERE 
             m.person_id = (SELECT person_id FROM person WHERE fodselsnr = ?)
         AND 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/MaksimumRepositoryTest.kt
@@ -79,6 +79,17 @@ class MaksimumRepositoryTest : H2TestBase("flyway/maksimum") {
     }
 
     @Test
+    fun `utbetalinger inneholder ikke duplikater når vi henter vedtak med perioder som går over flere år`() {
+        // En test som reproduserer en bug vi opplevde. Vi fikk duplikater av utbetalinger når vi hentet
+        // ut vedtak over flere år (f.eks. tilDato = NULL). Årsaken til dette er at MELDEKORTPERIODE har
+        // Primary key (periodekode, aar), men vi joinet kun på periodekode.
+        val resultat = repo.hentMaksimumsløsning("22222222222", LocalDate.of(2023, 1, 1), LocalDate.of(2024, 12, 31))
+
+        val vedtak = resultat.vedtak.single()
+        assertThat(vedtak.utbetaling).hasSize(1)
+    }
+
+    @Test
     fun `henter meldekortdata per utbetalingsperiode`() {
         val utbetalinger = repo.hentMaksimumsløsning(fnrMedVedtak, søkeperiodeFra, søkeperiodeTil)
             .vedtak.first().utbetaling

--- a/app/src/test/resources/flyway/maksimum/V2_1__insert_maksimum_testdata.sql
+++ b/app/src/test/resources/flyway/maksimum/V2_1__insert_maksimum_testdata.sql
@@ -103,3 +103,57 @@ insert into VEDTAK (VEDTAK_ID, SAK_ID, VEDTAKSTATUSKODE, VEDTAKTYPEKODE, UTFALLK
                     AKTFASEKODE, DATO_MOTTATT)
 values (90020, 9002, 'IVERK', 'O', 'JA', 'AAP', 102,
         DATE '2020-01-01', DATE '2020-12-31', '4402', 9002, 2020, 1, 'IKKE', DATE '2020-01-01');
+
+-- Person med åpent vedtak (til_dato = NULL) — brukes for å reprodusere duplikat-bug
+-- Bug: JOIN på MELDEKORTPERIODE mangler AND mkp.aar = m.aar, noe som gir én rad per år
+-- med samme periodekode. Med NULL til_dato blir søkevinduet stort nok til at flere
+-- år treffer datofilteret, og vi får duplikate utbetalingsrader.
+insert into PERSON(PERSON_ID, FODSELSNR, ETTERNAVN, FORNAVN)
+values (103, '22222222222', 'Åpen', 'Vedtak');
+
+Insert into SAK (SAK_ID, SAKSKODE, REG_DATO, REG_USER, MOD_DATO, MOD_USER, TABELLNAVNALIAS, OBJEKT_ID, AAR,
+                 LOPENRSAK, DATO_AVSLUTTET, SAKSTATUSKODE, AETATENHET_ANSVARLIG, PARTISJON, ER_UTLAND)
+values (9003, 'AA', DATE '2023-01-01', 'TEST', DATE '2023-01-01', 'TEST', 'PERS', 103, 2023, 9003, null, 'INAKT',
+        '4402', null, 'N');
+
+insert into VEDTAK (VEDTAK_ID, SAK_ID, VEDTAKSTATUSKODE, VEDTAKTYPEKODE, UTFALLKODE, RETTIGHETKODE,
+                    PERSON_ID, FRA_DATO, TIL_DATO, AETATENHET_BEHANDLER, LOPENRSAK, AAR, LOPENRVEDTAK,
+                    AKTFASEKODE, DATO_MOTTATT)
+values (90030, 9003, 'IVERK', 'O', 'JA', 'AAP', 103,
+        DATE '2023-01-01', NULL, '4402', 9003, 2023, 1, 'IKKE', DATE '2023-01-01');
+
+insert into VEDTAKFAKTA (VEDTAK_ID, VEDTAKFAKTAKODE, VEDTAKVERDI)
+values (90030, 'DAGSMBT', '500'),
+       (90030, 'BARNTILL', '0'),
+       (90030, 'DAGS', '500'),
+       (90030, 'BARNMSTON', '0'),
+       (90030, 'DAGSFSAM', '500'),
+       (90030, 'GRUNN', '400000'),
+       (90030, 'JUSTERTG', 'NyG2024');
+
+-- Meldekortperiode for 2023, periode 10 — finnes også for 2024 (samme periodekode, forskjellig år)
+-- Dette er det som trigger duplikater: JOIN uten AAR-betingelse treffer begge radene
+insert into MELDEKORTPERIODE (AAR, PERIODEKODE, UKENR_UKE1, UKENR_UKE2, DATO_FRA, DATO_TIL)
+values (2023, '10', 19, 20, DATE '2023-05-08', DATE '2023-05-21'),
+       (2024, '10', 19, 20, DATE '2024-05-06', DATE '2024-05-19');
+
+insert into MELDEKORT (MELDEKORT_ID, PERSON_ID, AAR, PERIODEKODE, MKSKORTKODE, BEREGNINGSTATUSKODE)
+values (6001, 103, 2023, '10', 'E1', 'FERDI');
+
+insert into MELDEKORTDAG (MELDEKORT_ID, UKENR, DAGNR, STATUS_ARBEIDSDAG, STATUS_KURS, STATUS_SYK, TIMER_ARBEIDET)
+values (6001, 19, 1, 'J', 'N', 'N', 3.0),
+       (6001, 19, 2, 'N', 'N', 'N', 0.0),
+       (6001, 19, 3, 'N', 'N', 'N', 0.0),
+       (6001, 19, 4, 'N', 'N', 'N', 0.0),
+       (6001, 19, 5, 'N', 'N', 'N', 0.0),
+       (6001, 20, 1, 'N', 'N', 'N', 0.0),
+       (6001, 20, 2, 'N', 'N', 'N', 0.0),
+       (6001, 20, 3, 'N', 'N', 'N', 0.0),
+       (6001, 20, 4, 'N', 'N', 'N', 0.0),
+       (6001, 20, 5, 'N', 'N', 'N', 0.0);
+
+insert into POSTERING (POSTERING_ID, BELOP, BELOPKODE, DATO_PERIODE_FRA, DATO_PERIODE_TIL, DATO_POSTERT, AAR,
+                       PERSON_ID, POSTERINGTYPEKODE, TRANSAKSJONSKODE, DATO_GRUNNLAG, VEDTAK_ID, ARTKODE,
+                       KAPITTEL, POST, UNDERPOST, BRUKER_ID_SAKSBEHANDLER, AETATENHET_ANSVARLIG, MELDEKORT_ID)
+values (9001, 5000, 'AAP', DATE '2023-05-08', DATE '2023-05-21', DATE '2023-05-25', 2023, 103,
+        'ORD', 'AA00', DATE '2023-05-08', 90030, 'ART', '2900', '01', '001', 'TEST', '4402', 6001);


### PR DESCRIPTION
Ved uthenting av utbetalinger joinet vi kun på periodekode, men ikke aar. Mens for tabellen er begge deler en del av primary-key. Siden periodekode ikke er unik alene førte dette til at dataene man fikk ut ble feil og enkelte meldekort-data ble duplisert på flere perioder.

Brukte copilot for å generere testdata her for å kunne reprodusere feilen.