### PR TITLE
For enklere testing: Støtte også bruk av saksnummer

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -16,6 +16,8 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.TellerRequest
 import no.nav.aap.arenaoppslag.modeller.ArenaSakDetaljertRespons
 import no.nav.aap.arenaoppslag.modeller.PersonId
+import no.nav.aap.arenaoppslag.modeller.SakId
+import no.nav.aap.arenaoppslag.modeller.Saksnummer
 import no.nav.aap.arenaoppslag.service.HistorikkService
 import no.nav.aap.arenaoppslag.service.PersonService
 import no.nav.aap.arenaoppslag.service.PosteringService
@@ -76,23 +78,29 @@ fun Route.maksdato(sakService: SakService, personService: PersonService) {
 
 fun Route.sak(sakOgVedtakService: SakOgVedtakService, telleverkService: TelleverkService) {
     get("/sak/{sakid}/detaljert") {
-        val sakid = call.parameters["sakid"]?.toIntOrNull()
+        val sakid = call.parameters["sakid"]
 
         if (sakid == null) {
-            logger.info("Sakid kan ikke være NULL eller et ugyldig tall")
+            logger.info("Sakid kan ikke være NULL")
             return@get call.respond(HttpStatusCode.BadRequest)
         }
 
-        when (val sak = sakOgVedtakService.hentSakMedVedtak(sakid)) {
-            null -> call.respond(status = HttpStatusCode.NotFound, message = "Fant ikke sak i Arena")
-            else -> {
-                val telleverk = telleverkService.hentTelleverkForPerson(PersonId(sak.person.personId))
-                val response = ArenaSakDetaljertRespons.fromDomain(sak, telleverk)
-
-                call.respond(status = HttpStatusCode.OK, message = response)
-            }
+        val sakidentifikator = Saksnummer.fromString(sakid) ?: SakId.fromString(sakid)
+        val sak = when (sakidentifikator) {
+            is SakId -> sakOgVedtakService.hentSakMedVedtak(saksId =  sakidentifikator)
+            is Saksnummer -> sakOgVedtakService.hentSakMedVedtak(saksnummer = sakidentifikator)
+            else -> null
         }
 
+        if (sak == null) {
+            logger.info("Klarte ikke hente sak for saksnummer $sakid")
+            return@get call.respond(HttpStatusCode.NotFound)
+        }
+
+        val telleverk = telleverkService.hentTelleverkForPerson(PersonId(sak.person.personId))
+        val response = ArenaSakDetaljertRespons.fromDomain(sak, telleverk)
+
+        call.respond(status = HttpStatusCode.OK, message = response)
     }
 }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
@@ -4,7 +4,10 @@ import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
 import no.nav.aap.arenaoppslag.database.VedtakfaktaRepository
 import no.nav.aap.arenaoppslag.database.VilkårsvurderingRepository
+import no.nav.aap.arenaoppslag.modeller.ArenaSak
 import no.nav.aap.arenaoppslag.modeller.ArenaSakMedVedtak
+import no.nav.aap.arenaoppslag.modeller.SakId
+import no.nav.aap.arenaoppslag.modeller.Saksnummer
 import no.nav.aap.arenaoppslag.modeller.toArenaSakMedVedtak
 
 class SakOgVedtakService(
@@ -13,10 +16,18 @@ class SakOgVedtakService(
     private val vedtakfaktaRepository: VedtakfaktaRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
 ) {
-    fun hentSakMedVedtak(saksId: Int): ArenaSakMedVedtak? {
+    fun hentSakMedVedtak(saksId: SakId): ArenaSakMedVedtak? {
         val sak = sakRepository.hentSak(saksId) ?: return null
+        return getArenaSakMedVedtak(sak)
+    }
 
-        val vedtak = vedtakRepository.hentVedtakForSak(saksId)
+    fun hentSakMedVedtak(saksnummer: Saksnummer): ArenaSakMedVedtak? {
+        val sak = sakRepository.hentSak(saksnummer) ?: return null
+        return getArenaSakMedVedtak(sak)
+    }
+
+    private fun getArenaSakMedVedtak(sak: ArenaSak): ArenaSakMedVedtak {
+        val vedtak = vedtakRepository.hentVedtakForSak(SakId(sak.sakId.toInt()))
         val vedtakIder = vedtak.map { it.vedtakId }
 
         val faktaPerVedtak = vedtakfaktaRepository.hentForVedtakIder(vedtakIder)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -5,16 +5,23 @@ import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
 import no.nav.aap.arenaoppslag.modeller.ArenaSakPerson
 import no.nav.aap.arenaoppslag.modeller.Maksdatolinje
 import no.nav.aap.arenaoppslag.modeller.PersonId
+import no.nav.aap.arenaoppslag.modeller.SakId
+import no.nav.aap.arenaoppslag.modeller.Saksnummer
 import org.intellij.lang.annotations.Language
 import java.sql.Connection
 import java.sql.ResultSet
 import javax.sql.DataSource
 
 class SakRepository(private val dataSource: DataSource) {
-
-    fun hentSak(saksId: Int): ArenaSak? {
+    fun hentSak(saksId: SakId): ArenaSak? {
         return dataSource.connection.use { con ->
             selectSakMedId(saksId, con)
+        }
+    }
+
+    fun hentSak(saksnummer: Saksnummer): ArenaSak? {
+        return dataSource.connection.use { con ->
+            selectSakMedSaksnummer(saksnummer, con)
         }
     }
 
@@ -63,9 +70,24 @@ class SakRepository(private val dataSource: DataSource) {
             }
         }
 
-        fun selectSakMedId(saksid: Int, connection: Connection): ArenaSak? {
+        fun selectSakMedId(saksid: SakId, connection: Connection): ArenaSak? {
             connection.prepareStatement(selectSakMedSaksId).use { preparedStatement ->
-                preparedStatement.setInt(1, saksid)
+                preparedStatement.setInt(1, saksid.id)
+                val resultSet = preparedStatement.executeQuery()
+                val saker = resultSet.map { row -> mapperForArenaSak(row) }
+
+                if (saker.isEmpty()) {
+                    return null
+                }
+
+                return saker.first()
+            }
+        }
+
+        fun selectSakMedSaksnummer(saksnummer: Saksnummer, connection: Connection): ArenaSak? {
+            connection.prepareStatement(selectSakMedSaksnummer).use { preparedStatement ->
+                preparedStatement.setInt(1, saksnummer.lopenummer)
+                preparedStatement.setInt(2, saksnummer.aar)
                 val resultSet = preparedStatement.executeQuery()
                 val saker = resultSet.map { row -> mapperForArenaSak(row) }
 
@@ -113,6 +135,16 @@ class SakRepository(private val dataSource: DataSource) {
             LEFT JOIN person ON person.person_id = sak.objekt_id
             LEFT JOIN sakstatus ON sak.sakstatuskode = sakstatus.sakstatuskode
             WHERE SAK_ID = ? AND TABELLNAVNALIAS='PERS'
+        """.trimIndent()
+
+        @Language("OracleSql")
+        internal val selectSakMedSaksnummer = """
+            SELECT sak.sak_id, sak.aar, sak.sakstatuskode, sakstatus.sakstatusnavn, sak.lopenrsak, person.person_id, 
+                person.fornavn, person.etternavn, person.fodselsnr, sak.reg_dato, sak.dato_avsluttet
+            FROM SAK
+            LEFT JOIN person ON person.person_id = sak.objekt_id
+            LEFT JOIN sakstatus ON sak.sakstatuskode = sakstatus.sakstatuskode
+            WHERE LOPENRSAK = ? AND AAR = ? AND TABELLNAVNALIAS='PERS'
         """.trimIndent()
 
         @Language("OracleSql")

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -5,6 +5,7 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.Status
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Periode
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtakRad
+import no.nav.aap.arenaoppslag.modeller.SakId
 import no.nav.aap.arenaoppslag.modeller.VedtakStatus
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.TestOnly
@@ -26,7 +27,7 @@ class VedtakRepository(private val dataSource: DataSource) {
         }
     }
 
-    fun hentVedtakForSak(saksId: Int): List<ArenaVedtakRad> {
+    fun hentVedtakForSak(saksId: SakId): List<ArenaVedtakRad> {
         return dataSource.connection.use { con ->
             selectVedtakForSak(saksId, con)
         }
@@ -109,9 +110,9 @@ class VedtakRepository(private val dataSource: DataSource) {
            AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
-        private fun selectVedtakForSak(sakId: Int, connection: Connection): List<ArenaVedtakRad> {
+        private fun selectVedtakForSak(sakId: SakId, connection: Connection): List<ArenaVedtakRad> {
             connection.createParameterizedQuery(selectVedtakForSak).use { preparedStatement ->
-                preparedStatement.setInt(1, sakId)
+                preparedStatement.setInt(1, sakId.id)
                 val resultSet = preparedStatement.executeQuery()
                 return resultSet.map { mapperForArenaVedtakRad(it) }.toList()
             }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/IdModeller.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/IdModeller.kt
@@ -1,0 +1,24 @@
+package no.nav.aap.arenaoppslag.modeller
+
+data class PersonId(val id: Int)
+
+data class SakId(val id: Int) {
+    companion object {
+        fun fromString(id: String): SakId? {
+            return id.toIntOrNull()?.let { SakId(it) }
+        }
+    }
+}
+
+data class Saksnummer(val lopenummer: Int, val aar: Int) {
+    companion object {
+        fun fromString(id: String): Saksnummer? {
+            if (!id.contains('-')) {
+                return null;
+            }
+
+            val (aar, lopenr) = id.split('-')
+            return Saksnummer(lopenummer = lopenr.toInt(), aar = aar.toInt())
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/PersonId.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/PersonId.kt
@@ -1,3 +1,0 @@
-package no.nav.aap.arenaoppslag.modeller
-
-data class PersonId(val id: Int)

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/SakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/SakRepositoryTest.kt
@@ -5,6 +5,7 @@ import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
 import no.nav.aap.arenaoppslag.modeller.ArenaSakPerson
 import no.nav.aap.arenaoppslag.modeller.Maksdatolinje
 import no.nav.aap.arenaoppslag.modeller.PersonId
+import no.nav.aap.arenaoppslag.modeller.SakId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,13 +37,13 @@ class SakRepositoryTest : H2TestBase("flyway/minimumtest", "flyway/saklistetest"
                 etternavn = "Bestesen",
             )
         )
-        val sak = sakRepository.hentSak(1)
+        val sak = sakRepository.hentSak(SakId(1))
         assertThat(sak).isEqualTo(forventetSak)
     }
 
     @Test
     fun `returnerer NULL om saken ikke finnes i databasen`() {
-        val sak = sakRepository.hentSak(1919191919)
+        val sak = sakRepository.hentSak(SakId(1919191919))
         assertThat(sak).isNull()
     }
 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepositoryTest.kt
@@ -2,6 +2,7 @@ package no.nav.aap.arenaoppslag.database
 
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtakRad
+import no.nav.aap.arenaoppslag.modeller.SakId
 import no.nav.aap.arenaoppslag.modeller.VedtakStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -53,7 +54,7 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
             relatertVedtak = null,
         )
 
-        val alleVedtak = vedtakRepository.hentVedtakForSak(1)
+        val alleVedtak = vedtakRepository.hentVedtakForSak(SakId(1))
 
         assertThat(alleVedtak).containsExactly(forventetVedtak)
     }
@@ -61,14 +62,14 @@ class VedtakRepositoryTest : H2TestBase("flyway/minimumtest") {
     @Test
     fun `hentVedtakForSak returnerer tom liste om det ikke er noen vedtak knyttet til denne saken`() {
         val vedtakRepository = VedtakRepository(h2)
-        val alleVedtak = vedtakRepository.hentVedtakForSak(1919191919)
+        val alleVedtak = vedtakRepository.hentVedtakForSak(SakId(1919191919))
         assertThat(alleVedtak).isEmpty()
     }
 
     @Test
     fun `hentVedtakForSak returnerer vedtak med relatertVedtak satt`() {
         val vedtakRepository = VedtakRepository(h2)
-        val vedtak = vedtakRepository.hentVedtakForSak(9)
+        val vedtak = vedtakRepository.hentVedtakForSak(SakId(9))
 
         assertThat(vedtak).hasSize(1)
         assertThat(vedtak.single().relatertVedtak).isEqualTo(1234)


### PR DESCRIPTION
Lar endepunktet for å hente detaljert informasjon om en sak også støtte at man sender inn saksnummer som alternativ til SakId. På den måten gjør det at vi enklere kan teste ting. I mange tilfeller gir det mer mening å bruke saksnummeret enn sakId som er en intern ID.