### PR TITLE
Gjør modell og kontrakt mer enhetlig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Domain objects must **never** be returned directly from a route — map them to 
 
 ### Mapping from domain to response
 
-Use one of two patterns — pick whichever is most readable in context:
+Use `tilKontrakt()` on domain objects as the default mapping pattern:
 
 **Pattern 1 — method on the domain class (`tilKontrakt()`):**
 
@@ -149,33 +149,9 @@ data class Periode(val fraOgMedDato: LocalDate, val tilOgMedDato: LocalDate?) {
 }
 ```
 
-Use this when one domain object maps to one contract/response object.
+Use this both for simple 1:1 mappings and for richer responses that include related domain data.
 
-**Pattern 2 — `companion object { fun fromDomain(...) }` on the response class:**
-
-```kotlin
-data class ArenaSakDetaljertRespons(
-    val sakId: String,
-    // ...
-) {
-    companion object {
-        fun fromDomain(sak: ArenaSakMedVedtak, telleverk: TellerverkPåPerson?) =
-            ArenaSakDetaljertRespons(
-                sakId = sak.sakId,
-                // ...
-            )
-    }
-}
-```
-
-Use this when the response is assembled from multiple domain objects at the route level.
-
-In the route handler:
-
-```kotlin
-val respons = ArenaSakDetaljertRespons.fromDomain(sak, telleverk)
-call.respond(HttpStatusCode.OK, respons)
-```
+In route handlers, call `tilKontrakt()` on the domain object and respond with the mapped contract type.
 
 ### Database access pattern
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -108,7 +108,7 @@ fun Route.sak(sakOgVedtakService: SakOgVedtakService, telleverkService: Tellever
     }
 }
 
-fun Route.vedtakForPerson(sakOgVedtakService: SakOgVedtakService, personService: PersonService) {
+fun Route.vedtakDetaljerForPerson(sakOgVedtakService: SakOgVedtakService, personService: PersonService) {
     post("/person/vedtak") {
         logger.info("Henter alle vedtak for person")
         val request: VedtakForPersonRequest = call.receive()
@@ -116,7 +116,7 @@ fun Route.vedtakForPerson(sakOgVedtakService: SakOgVedtakService, personService:
         val personId = personService.hentPersonId(request.personidentifikator)
             ?: return@post call.respond(HttpStatusCode.NotFound, "Fant ikke personen i Arena")
 
-        val vedtak: List<ArenaVedtakMedDetaljer> = sakOgVedtakService.hentVedtakForPerson(personId)
+        val vedtak: List<ArenaVedtakMedDetaljer> = sakOgVedtakService.hentVedtakDetaljerForPerson(personId)
             .map { it.tilKontrakt() }
 
         call.respond(HttpStatusCode.OK, vedtak)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -4,7 +4,7 @@ import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljerKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
@@ -116,7 +116,7 @@ fun Route.vedtakForPerson(sakOgVedtakService: SakOgVedtakService, personService:
         val personId = personService.hentPersonId(request.personidentifikator)
             ?: return@post call.respond(HttpStatusCode.NotFound, "Fant ikke personen i Arena")
 
-        val vedtak: List<ArenaVedtakMedDetaljerKontrakt> = sakOgVedtakService.hentVedtakForPerson(personId)
+        val vedtak: List<ArenaVedtakMedDetaljer> = sakOgVedtakService.hentVedtakForPerson(personId)
             .map { it.tilKontrakt() }
 
         call.respond(HttpStatusCode.OK, vedtak)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -15,7 +15,6 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.TellerRequest
-import no.nav.aap.arenaoppslag.modeller.ArenaSakDetaljertRespons
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.SakId
@@ -104,7 +103,7 @@ fun Route.sak(sakOgVedtakService: SakOgVedtakService, telleverkService: Tellever
         val telleverk = telleverkService.hentTelleverkForPerson(personId)
 
         logger.info("Henter saksdetaljer")
-        val response = ArenaSakDetaljertRespons.fromDomain(sak, telleverk,kvoteHistorikk)
+        val response = sak.tilKontrakt(telleverk, kvoteHistorikk)
         call.respond(status = HttpStatusCode.OK, message = response)
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -4,6 +4,7 @@ import io.ktor.http.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljerKontrakt
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
@@ -15,7 +16,6 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.TellerRequest
 import no.nav.aap.arenaoppslag.modeller.ArenaSakDetaljertRespons
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljerKontrakt
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.SakId

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -237,7 +237,7 @@ private fun Application.routes(datasource: DataSource, pdlGateway: IPdlGateway) 
                 sakerForPerson(sakListeService, personService)
                 maksdato(sakListeService, personService)
                 utbetalinger(utbetalingService, personService)
-                vedtakForPerson(sakOgVedtakService, personService)
+                vedtakDetaljerForPerson(sakOgVedtakService, personService)
             }
             route("/api/intern") {
                 // Nye interne APIer, disse skal kun konsumeres av team-aap-migrering sine applikasjoner

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -14,6 +14,10 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import no.nav.aap.arenaoppslag.Metrics.prometheus
 import no.nav.aap.arenaoppslag.database.ArenaDatasource
 import no.nav.aap.arenaoppslag.database.HistorikkRepository
@@ -26,6 +30,7 @@ import no.nav.aap.arenaoppslag.database.TelleverkRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
 import no.nav.aap.arenaoppslag.database.VedtakfaktaRepository
 import no.nav.aap.arenaoppslag.database.VilkårsvurderingRepository
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.pdl.IPdlGateway
 import no.nav.aap.arenaoppslag.pdl.PdlGateway
 import no.nav.aap.arenaoppslag.plugins.MdcKeys
@@ -97,7 +102,10 @@ fun Application.server(
 
     routes(datasource, pdlGateway)
 
-    databaseConnectionWarmup(skapHistorikkService(datasource))
+    warmup(
+        datasource,
+        pdlGateway,
+    )
 
     monitor.subscribe(ApplicationStarted) { environment ->
         environment.log.info("ktor har startet opp.")
@@ -129,9 +137,32 @@ fun Application.server(
     }
 }
 
-private fun databaseConnectionWarmup(historikkService: HistorikkService) {
-    // Dette gjøres for å unngå at etter redeploy tar første query 2-3 sekund
-    historikkService.signifikanteSakerForPerson(setOf("007"), LocalDate.now())
+private fun Application.warmup(
+    datasource: DataSource,
+    pdlGateway: IPdlGateway
+) {
+    val historikkService = skapHistorikkService(datasource)
+    val sakService = skapSakListeService(datasource)
+    val fiktivtFødselsnummer = "007"
+    val fiktivArenaPerson = PersonId(0xcafebabe.toInt())
+
+    launch {
+        try {
+            withContext(Dispatchers.IO) {
+                // Dette gjøres for å unngå at etter redeploy tar første query 2-3 sekund
+                historikkService.signifikanteSakerForPerson(setOf(fiktivtFødselsnummer), LocalDate.now())
+
+                // Generell innlasting av objektgraf og cache-opprettelse
+                pdlGateway.hentAlleIdenterForPerson(fiktivtFødselsnummer)
+                sakService.hentSakerForPerson(fiktivArenaPerson)
+            }
+        } catch (e: CancellationException) {
+            logger.info("Warmup avbrutt fordi applikasjonen stopper.")
+            throw e
+        } catch (e: Exception) {
+            logger.warn("Warmup feilet, fortsetter oppstart uten warmup.", e)
+        }
+    }
 }
 
 // Bruker ikke RepositoryRegistry fra Kelvin-komponenter fordi vi er på Oracle DB her,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/SakOgVedtakService.kt
@@ -28,7 +28,7 @@ class SakOgVedtakService(
         return getArenaSakMedVedtak(sak)
     }
 
-    fun hentVedtakForPerson(personId: PersonId): List<ArenaVedtakMedDetaljer> {
+    fun hentVedtakDetaljerForPerson(personId: PersonId): List<ArenaVedtakMedDetaljer> {
         val saker = sakRepository.hentSakerDetaljerForPerson(personId)
         return saker.flatMap { sak -> getArenaSakMedVedtak(sak).vedtak }
     }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/TelleverkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/TelleverkRepository.kt
@@ -1,24 +1,10 @@
 package no.nav.aap.arenaoppslag.database;
 
+import no.nav.aap.arenaoppslag.modeller.KvoteVerdi
+import no.nav.aap.arenaoppslag.modeller.KvotebrukHendelse
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.intellij.lang.annotations.Language
-import java.time.LocalDate
 import javax.sql.DataSource;
-
-
-data class KvoteVerdi(val kode: String, val verdi: Int)
-
-data class KvotebrukHendelse(
-    val id: Int,
-    val kvoteTypeKode: String,
-    val endringsGrunnlag: String,
-    val antallBevegelse: Int,
-    val posteringTypeKode: String,
-    val datoHendelse: LocalDate,
-    val resterende: Int,
-    val modUser: String?,
-    val begrunnelse: String?,
-)
 
 
 class TelleverkRepository(private val datasource: DataSource) {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ArenaSakDetaljert.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ArenaSakDetaljert.kt
@@ -2,8 +2,7 @@ package no.nav.aap.arenaoppslag.modeller
 
 import java.time.LocalDateTime
 
-@Suppress("MatchingDeclarationName")
-data class ArenaSakDetaljertRespons(
+data class ArenaSakDetaljert(
     val sakId: String,
     val opprettetAar: Int,
     val lopenr: Int,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ArenaSakDetaljertRespons.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ArenaSakDetaljertRespons.kt
@@ -15,25 +15,5 @@ data class ArenaSakDetaljertRespons(
     val vedtak: List<ArenaVedtakMedDetaljer>,
     val telleverkForPerson: TelleverkForPerson?,
     val kvoteHistorikk: Set<KvotebrukHendelse>
-) {
-    companion object {
-        fun fromDomain(
-            arenaSakMedVedtak: ArenaSakMedVedtak,
-            telleverkForPerson: TelleverkForPerson?,
-            kvoteHistorikk: Set<KvotebrukHendelse>
-        ) = ArenaSakDetaljertRespons(
-            sakId = arenaSakMedVedtak.sakId,
-            opprettetAar = arenaSakMedVedtak.opprettetAar,
-            lopenr = arenaSakMedVedtak.lopenr,
-            person = arenaSakMedVedtak.person,
-            statuskode = arenaSakMedVedtak.statuskode,
-            statusnavn = arenaSakMedVedtak.statusnavn,
-            registrertDato = arenaSakMedVedtak.registrertDato,
-            avsluttetDato = arenaSakMedVedtak.avsluttetDato,
-            vedtak = arenaSakMedVedtak.vedtak,
-            telleverkForPerson = telleverkForPerson,
-            kvoteHistorikk = kvoteHistorikk
-        )
-    }
-}
+)
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ArenaSakDetaljertRespons.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/ArenaSakDetaljertRespons.kt
@@ -1,6 +1,5 @@
 package no.nav.aap.arenaoppslag.modeller
 
-import no.nav.aap.arenaoppslag.database.KvotebrukHendelse
 import java.time.LocalDateTime
 
 @Suppress("MatchingDeclarationName")

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Kvote.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Kvote.kt
@@ -1,0 +1,17 @@
+package no.nav.aap.arenaoppslag.modeller
+
+import java.time.LocalDate
+
+data class KvoteVerdi(val kode: String, val verdi: Int)
+
+data class KvotebrukHendelse(
+    val id: Int,
+    val kvoteTypeKode: String,
+    val endringsGrunnlag: String,
+    val antallBevegelse: Int,
+    val posteringTypeKode: String,
+    val datoHendelse: LocalDate,
+    val resterende: Int,
+    val modUser: String?,
+    val begrunnelse: String?,
+)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Periode.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Periode.kt
@@ -16,17 +16,6 @@ data class Periode(
     }
 }
 
-data class VedtakFakta(
-    var dagsmbt: Int,
-    var dags: Int,
-    var barntill: Int,
-    var satsbarntg: Int,
-    var barnmston: Int,
-    var dagsfsam: Int,
-    var justertg: String?,
-)
-
-
 data class PeriodeMed11_17(
     val periode: Periode,
     val aktivitetsfaseKode: String,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
@@ -107,7 +107,7 @@ data class ArenaSakMedVedtak(
     fun tilKontrakt(
         telleverkForPerson: TelleverkForPerson?,
         kvoteHistorikk: Set<KvotebrukHendelse>
-    ) = ArenaSakDetaljertRespons(
+    ) = ArenaSakDetaljert(
         sakId = sakId,
         opprettetAar = opprettetAar,
         lopenr = lopenr,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
@@ -103,7 +103,24 @@ data class ArenaSakMedVedtak(
     val registrertDato: LocalDateTime,
     val avsluttetDato: LocalDateTime?,
     val vedtak: List<ArenaVedtakMedDetaljer>
-)
+) {
+    fun tilKontrakt(
+        telleverkForPerson: TelleverkForPerson?,
+        kvoteHistorikk: Set<KvotebrukHendelse>
+    ) = ArenaSakDetaljertRespons(
+        sakId = sakId,
+        opprettetAar = opprettetAar,
+        lopenr = lopenr,
+        person = person,
+        statuskode = statuskode,
+        statusnavn = statusnavn,
+        registrertDato = registrertDato,
+        avsluttetDato = avsluttetDato,
+        vedtak = vedtak,
+        telleverkForPerson = telleverkForPerson,
+        kvoteHistorikk = kvoteHistorikk
+    )
+}
 
 data class ArenaSakPerson(
     val personId: Int,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -3,8 +3,9 @@ package no.nav.aap.arenaoppslag.modeller
 import no.nav.aap.arenaoppslag.kontrakt.intern.Kilde
 import no.nav.aap.arenaoppslag.kontrakt.intern.Status
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Periode
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljerKontrakt
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakfaktaKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer as ArenaVedtakMedDetaljerKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakfakta as ArenaVedtakfaktaKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVilkårsvurdering as ArenaVilkårsvurderingKontrakt
 import java.time.LocalDate
 
 data class VedtakStatus(

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/VedtakFakta.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/VedtakFakta.kt
@@ -1,0 +1,11 @@
+package no.nav.aap.arenaoppslag.modeller
+
+data class VedtakFakta(
+    var dagsmbt: Int,
+    var dags: Int,
+    var barntill: Int,
+    var satsbarntg: Int,
+    var barnmston: Int,
+    var dagsfsam: Int,
+    var justertg: String?,
+)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TelleverkService.kt
@@ -1,7 +1,7 @@
 package no.nav.aap.arenaoppslag.service
 
-import no.nav.aap.arenaoppslag.database.KvotebrukHendelse
 import no.nav.aap.arenaoppslag.database.TelleverkRepository
+import no.nav.aap.arenaoppslag.modeller.KvotebrukHendelse
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.TelleverkForPerson
 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/VedtakForPersonApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/VedtakForPersonApiTest.kt
@@ -16,7 +16,7 @@ class VedtakForPersonApiTest : H2TestBase("flyway/minimumtest") {
         withTestServer(h2) { gateway ->
             // Person med fodselsnr '123' har én sak med ett vedtak (id=1234)
             val vedtak: List<ArenaVedtakMedDetaljer> =
-                gateway.hentVedtakForPerson(VedtakForPersonRequest("123"))
+                gateway.hentVedtakDetaljerForPerson(VedtakForPersonRequest("123"))
 
             assertThat(vedtak).isNotEmpty()
             assertThat(vedtak.first().vedtakId).isEqualTo(1234)
@@ -27,7 +27,7 @@ class VedtakForPersonApiTest : H2TestBase("flyway/minimumtest") {
     fun `Returnerer 404 for ukjent person`() {
         withTestServer(h2) { gateway ->
             val resultat = runCatching {
-                gateway.hentVedtakForPerson(VedtakForPersonRequest("007"))
+                gateway.hentVedtakDetaljerForPerson(VedtakForPersonRequest("007"))
             }
             val feil = resultat.exceptionOrNull() as? ClientRequestException
             assertThat(feil).isNotNull
@@ -40,7 +40,7 @@ class VedtakForPersonApiTest : H2TestBase("flyway/minimumtest") {
         withTestServer(h2) { gateway ->
             // Person med fodselsnr 'ingenvedtak' eksisterer i Arena men har ingen saker
             val vedtak: List<ArenaVedtakMedDetaljer> =
-                gateway.hentVedtakForPerson(VedtakForPersonRequest("ingenvedtak"))
+                gateway.hentVedtakDetaljerForPerson(VedtakForPersonRequest("ingenvedtak"))
 
             assertThat(vedtak).isEmpty()
         }

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/VedtakForPersonApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/VedtakForPersonApiTest.kt
@@ -4,7 +4,7 @@ import io.ktor.client.plugins.*
 import io.ktor.http.*
 import no.nav.aap.arenaoppslag.client.ArenaOppslagGateway.Companion.withTestServer
 import no.nav.aap.arenaoppslag.database.H2TestBase
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljerKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -15,7 +15,7 @@ class VedtakForPersonApiTest : H2TestBase("flyway/minimumtest") {
     fun `Henter vedtak for kjent person`() {
         withTestServer(h2) { gateway ->
             // Person med fodselsnr '123' har én sak med ett vedtak (id=1234)
-            val vedtak: List<ArenaVedtakMedDetaljerKontrakt> =
+            val vedtak: List<ArenaVedtakMedDetaljer> =
                 gateway.hentVedtakForPerson(VedtakForPersonRequest("123"))
 
             assertThat(vedtak).isNotEmpty()
@@ -39,7 +39,7 @@ class VedtakForPersonApiTest : H2TestBase("flyway/minimumtest") {
     fun `Henter tom liste for person uten saker`() {
         withTestServer(h2) { gateway ->
             // Person med fodselsnr 'ingenvedtak' eksisterer i Arena men har ingen saker
-            val vedtak: List<ArenaVedtakMedDetaljerKontrakt> =
+            val vedtak: List<ArenaVedtakMedDetaljer> =
                 gateway.hentVedtakForPerson(VedtakForPersonRequest("ingenvedtak"))
 
             assertThat(vedtak).isEmpty()

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
@@ -11,7 +11,7 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import no.nav.aap.arenaoppslag.TestConfig
 import no.nav.aap.arenaoppslag.TestConfig.jsonHttpClient
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljerKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
@@ -85,8 +85,8 @@ class ArenaOppslagGateway(private val tokenProvider: AzureTokenGen, private val 
 
     suspend fun hentVedtakForPerson(
         req: VedtakForPersonRequest
-    ): List<ArenaVedtakMedDetaljerKontrakt> =
-        gjørArenaOppslag<List<ArenaVedtakMedDetaljerKontrakt>, VedtakForPersonRequest>(
+    ): List<ArenaVedtakMedDetaljer> =
+        gjørArenaOppslag<List<ArenaVedtakMedDetaljer>, VedtakForPersonRequest>(
             "/api/v1/person/vedtak", req
         ).getOrThrow()
 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
@@ -83,7 +83,7 @@ class ArenaOppslagGateway(private val tokenProvider: AzureTokenGen, private val 
             "/api/v1/utbetalinger/siste", req
         ).getOrThrow()
 
-    suspend fun hentVedtakForPerson(
+    suspend fun hentVedtakDetaljerForPerson(
         req: VedtakForPersonRequest
     ): List<ArenaVedtakMedDetaljer> =
         gjørArenaOppslag<List<ArenaVedtakMedDetaljer>, VedtakForPersonRequest>(

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/TelleverkForPersonRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/TelleverkForPersonRepositoryTest.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.arenaoppslag.database
 
+import no.nav.aap.arenaoppslag.modeller.KvoteVerdi
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/SakOgVedtakServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/SakOgVedtakServiceTest.kt
@@ -29,7 +29,7 @@ class SakOgVedtakServiceTest {
     )
 
     @Test
-    fun `hentVedtakForPerson returnerer flattened vedtakliste fra alle saker`() {
+    fun `hentVedtakDetaljerForPerson returnerer flattened vedtakliste fra alle saker`() {
         val personId = PersonId(42)
         val sak1 = lagArenaSak(sakId = "1")
         val sak2 = lagArenaSak(sakId = "2")
@@ -42,18 +42,18 @@ class SakOgVedtakServiceTest {
         every { vilkårsvurderingRepository.hentForVedtakIder(listOf(101, 102)) } returns emptyMap()
         every { vilkårsvurderingRepository.hentForVedtakIder(listOf(201)) } returns emptyMap()
 
-        val vedtak = service.hentVedtakForPerson(personId)
+        val vedtak = service.hentVedtakDetaljerForPerson(personId)
 
         assertThat(vedtak).hasSize(3)
         assertThat(vedtak.map { it.vedtakId }).containsExactlyInAnyOrder(101, 102, 201)
     }
 
     @Test
-    fun `hentVedtakForPerson returnerer tom liste når person ikke har saker`() {
+    fun `hentVedtakDetaljerForPerson returnerer tom liste når person ikke har saker`() {
         val personId = PersonId(99)
         every { sakRepository.hentSakerDetaljerForPerson(personId) } returns emptyList()
 
-        val vedtak = service.hentVedtakForPerson(personId)
+        val vedtak = service.hentVedtakDetaljerForPerson(personId)
 
         assertThat(vedtak).isEmpty()
     }

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakerResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakerResponse.kt
@@ -67,7 +67,7 @@ public data class SisteUtbetalingerResponse(val utbetalingsdato: LocalDate?)
 public data class SakMedSisteUtbetaling(val sakId: Int, val sisteAAPUtbetalingsdato: LocalDate?)
 
 // SakstypeKontrakt er foreløpig ikke i bruk, men beholdes for fremtidig bruk med enum-basert sakstype
-public enum class SakstypeKontrakt {
+public enum class Sakstype {
     AA,
     ARBEID,
     ATTF,

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/VedtakResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/VedtakResponse.kt
@@ -4,7 +4,10 @@ import java.time.LocalDate
 
 public data class VedtakForPersonRequest(val personidentifikator: String)
 
-public data class ArenaVedtakMedDetaljerKontrakt(
+@Deprecated("bruk nytt navn uten -Kontrakt suffiks", level= DeprecationLevel.ERROR)
+public typealias ArenaVedtakMedDetaljerKontrakt = ArenaVedtakMedDetaljer
+
+public data class ArenaVedtakMedDetaljer(
     val vedtakId: Int,
     val lopenrvedtak: Int,
     val statusKode: String,
@@ -22,17 +25,23 @@ public data class ArenaVedtakMedDetaljerKontrakt(
     val saksbehandler: String?,
     val beslutter: String?,
     val relatertVedtak: Int?,
-    val fakta: List<ArenaVedtakfaktaKontrakt>
+    val fakta: List<ArenaVedtakfakta>
 )
 
-public data class ArenaVedtakfaktaKontrakt(
+@Deprecated("bruk nytt navn uten -Kontrakt suffiks", level= DeprecationLevel.ERROR)
+public typealias ArenaVedtakfaktaKontrakt = ArenaVedtakfakta
+
+public data class ArenaVedtakfakta(
     val kode: String,
     val navn: String,
     val verdi: String?,
     val registrertDato: LocalDate,
 )
 
-public data class ArenaVilkårsvurderingKontrakt(
+@Deprecated("bruk nytt navn uten -Kontrakt suffiks", level= DeprecationLevel.ERROR)
+public typealias ArenaVilkårsvurderingKontrakt = ArenaVilkårsvurdering
+
+public data class ArenaVilkårsvurdering(
     val vilkårsvurderingId: Long,
     val vilkårkode: String,
     val begrunnelse: String?,


### PR DESCRIPTION
Mindre opprydding. 
Endrer navn på en eksisterende kontrakt-type for å bli konsistent med resten (unngå formatet kontrakt.TypenavnKontrakt)