### PR TITLE
Et forslag på tilgangskontroll

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -15,15 +15,18 @@ import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.TellerRequest
+import no.nav.aap.arenaoppslag.modeller.ArenaSakMedVedtak
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.modeller.PersonId
-import no.nav.aap.arenaoppslag.modeller.SakId
-import no.nav.aap.arenaoppslag.modeller.Saksnummer
+import no.nav.aap.arenaoppslag.modeller.SakIdentifikator
 import no.nav.aap.arenaoppslag.service.HistorikkService
 import no.nav.aap.arenaoppslag.service.PersonService
 import no.nav.aap.arenaoppslag.service.PosteringService
+import no.nav.aap.arenaoppslag.service.SakOgVedtakService
 import no.nav.aap.arenaoppslag.service.SakService
 import no.nav.aap.arenaoppslag.service.TelleverkService
+import no.nav.aap.arenaoppslag.service.TilgangService
+import no.nav.aap.arenaoppslag.util.token
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 
 fun Route.historikk(historikkService: HistorikkService) {
@@ -77,7 +80,7 @@ fun Route.maksdato(sakService: SakService, personService: PersonService) {
     }
 }
 
-fun Route.sak(sakService: SakService, posteringService: PosteringService, sakOgVedtakService: SakOgVedtakService, telleverkService: TelleverkService) {
+fun Route.sak(sakService: SakService, posteringService: PosteringService, sakOgVedtakService: SakOgVedtakService, telleverkService: TelleverkService, tilgangService: TilgangService) {
     get("/sak/{sakid}/detaljert") {
         val sakid = call.parameters["sakid"]
 
@@ -86,27 +89,36 @@ fun Route.sak(sakService: SakService, posteringService: PosteringService, sakOgV
             return@get call.respond(HttpStatusCode.BadRequest)
         }
 
-        val sakidentifikator = Saksnummer.fromString(sakid) ?: SakId.fromString(sakid)
-        val sak = when (sakidentifikator) {
-            is SakId -> sakOgVedtakService.hentSakMedVedtak(saksId =  sakidentifikator)
-            is Saksnummer -> sakOgVedtakService.hentSakMedVedtak(saksnummer = sakidentifikator)
-            else -> null
+        val sakIdentifikator = SakIdentifikator.fromString(sakid)
+
+        if (sakIdentifikator == null) {
+            logger.info("Klarte ikke tolke saksnummer: $sakid")
+            return@get call.respond(HttpStatusCode.BadRequest)
         }
 
-        if (sak == null) {
-            logger.info("Klarte ikke hente sak for saksnummer $sakid")
-            return@get call.respond(HttpStatusCode.NotFound)
-        }
-        val personId = PersonId(sak.person.personId)
+        tilgangService.harTilgangTilSak(sakIdentifikator, call.token())
+            .mapNotNull { sakOgVedtakService.hentSakMedVedtak(sakIdentifikator) }
+            .map { sak: ArenaSakMedVedtak ->
+                val personId = PersonId(sak.person.personId)
 
-        val kvoteHistorikk = telleverkService.hentKvoteBrukHendelserForPerson(personId)
-        val telleverk = telleverkService.hentTelleverkForPerson(personId)
-        val maksdato = sakService.hentMaksdatoAapForPerson(personId)
-        val sisteUtbetalingDato = posteringService.hentSisteAapUtbetalingForPerson(personId)
+                logger.info("Henter saksdetaljer")
+                val kvoteHistorikk = telleverkService.hentKvoteBrukHendelserForPerson(personId)
+                val telleverk = telleverkService.hentTelleverkForPerson(personId)
+                val maksdato = sakService.hentMaksdatoAapForPerson(personId)
+                val sisteUtbetalingDato = posteringService.hentSisteAapUtbetalingForPerson(personId)
 
-        logger.info("Henter saksdetaljer")
-        val response = sak.tilKontrakt( telleverk,kvoteHistorikk,sisteUtbetalingDato,maksdato)
-        call.respond(status = HttpStatusCode.OK, message = response)
+                sak.tilKontrakt( telleverk,kvoteHistorikk,sisteUtbetalingDato,maksdato)
+            }.fold(
+                suksess = { call.respond(status = HttpStatusCode.OK, message = it) },
+                ikkeFunnet = {
+                    logger.info("Klarte ikke hente sak for saksnummer $sakid")
+                    call.respond(HttpStatusCode.NotFound)
+                },
+                ikkeTilgang = {
+                    logger.info("Bruker har ikke tilgang til å behandle sak $sakid")
+                    call.respond(HttpStatusCode.Forbidden)
+                }
+            )
     }
 }
 
@@ -125,18 +137,22 @@ fun Route.vedtakDetaljerForPerson(sakOgVedtakService: SakOgVedtakService, person
     }
 }
 
-fun Route.telleverk(telleverkService: TelleverkService, personService: PersonService) {
+fun Route.telleverk(telleverkService: TelleverkService, personService: PersonService, tilgangService: TilgangService) {
     post("/telleverk") {
         logger.info("Henter telleverk")
         val request: TellerRequest = call.receive()
-
         val personidentifikator = request.personidentifikator
-        val personId = personService.hentPersonId(personidentifikator)
-            ?: return@post call.respond(HttpStatusCode.NotFound, "Fant ikke personen i Arena")
 
-        val telleverk = telleverkService.hentTelleverkForPerson(personId)
-            ?: return@post call.respond(HttpStatusCode.NotFound, "Fant ikke telleverk for personen i Arena")
-        call.respond(status = HttpStatusCode.OK, message = telleverk)
+        tilgangService.harTilgangTilPerson(personidentifikator, call.token())
+            .mapNotNull { personService.hentPersonId(personidentifikator) }
+            .onError { logger.info("Fant ikke person i Arena for henting av telleverk") }
+            .mapNotNull { telleverkService.hentTelleverkForPerson(it) }
+            .onError { logger.info("Fant ikke telleverk for person i Arena") }
+            .fold(
+                suksess = { call.respond(status = HttpStatusCode.OK, message = it) },
+                ikkeFunnet = { call.respond(HttpStatusCode.NotFound, "Fant ikke telleverk for person") },
+                ikkeTilgang = { call.respond(HttpStatusCode.Forbidden) }
+            )
     }
 }
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -38,6 +38,7 @@ import no.nav.aap.arenaoppslag.service.HistorikkService
 import no.nav.aap.arenaoppslag.service.InternService
 import no.nav.aap.arenaoppslag.service.PersonService
 import no.nav.aap.arenaoppslag.service.PosteringService
+import no.nav.aap.arenaoppslag.service.SakOgVedtakService
 import no.nav.aap.arenaoppslag.service.SakService
 import no.nav.aap.arenaoppslag.service.TelleverkService
 import org.slf4j.LoggerFactory

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/IdModeller.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/IdModeller.kt
@@ -2,7 +2,15 @@ package no.nav.aap.arenaoppslag.modeller
 
 data class PersonId(val id: Int)
 
-data class SakId(val id: Int) {
+sealed class SakIdentifikator {
+    companion object {
+        fun fromString(id: String): SakIdentifikator? {
+            return Saksnummer.fromString(id) ?: SakId.fromString(id)
+        }
+    }
+}
+
+data class SakId(val id: Int): SakIdentifikator() {
     companion object {
         fun fromString(id: String): SakId? {
             return id.toIntOrNull()?.let { SakId(it) }
@@ -10,7 +18,7 @@ data class SakId(val id: Int) {
     }
 }
 
-data class Saksnummer(val lopenummer: Int, val aar: Int) {
+data class Saksnummer(val lopenummer: Int, val aar: Int): SakIdentifikator() {
     companion object {
         fun fromString(id: String): Saksnummer? {
             if (!id.contains('-')) {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakOgVedtakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakOgVedtakService.kt
@@ -1,4 +1,4 @@
-package no.nav.aap.arenaoppslag
+package no.nav.aap.arenaoppslag.service
 
 import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.database.VedtakRepository
@@ -9,6 +9,7 @@ import no.nav.aap.arenaoppslag.modeller.ArenaVedtakMedDetaljer
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.ArenaSakMedVedtak
 import no.nav.aap.arenaoppslag.modeller.SakId
+import no.nav.aap.arenaoppslag.modeller.SakIdentifikator
 import no.nav.aap.arenaoppslag.modeller.Saksnummer
 import no.nav.aap.arenaoppslag.modeller.toArenaSakMedVedtak
 
@@ -18,6 +19,13 @@ class SakOgVedtakService(
     private val vedtakfaktaRepository: VedtakfaktaRepository,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
 ) {
+    fun hentSakMedVedtak(sakIdentifikator: SakIdentifikator): ArenaSakMedVedtak? {
+        return when(sakIdentifikator) {
+            is SakId -> hentSakMedVedtak(sakIdentifikator)
+            is Saksnummer -> hentSakMedVedtak(sakIdentifikator)
+        }
+    }
+
     fun hentSakMedVedtak(saksId: SakId): ArenaSakMedVedtak? {
         val sak = sakRepository.hentSak(saksId) ?: return null
         return getArenaSakMedVedtak(sak)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/SakService.kt
@@ -7,7 +7,11 @@ import no.nav.aap.arenaoppslag.database.SakRepository
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakMedSisteVedtakOgMaksdato
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
 import no.nav.aap.arenaoppslag.modeller.ArenaSakOppsummering
+import no.nav.aap.arenaoppslag.modeller.ArenaSakPerson
 import no.nav.aap.arenaoppslag.modeller.PersonId
+import no.nav.aap.arenaoppslag.modeller.SakId
+import no.nav.aap.arenaoppslag.modeller.SakIdentifikator
+import no.nav.aap.arenaoppslag.modeller.Saksnummer
 import java.time.LocalDate
 import java.util.concurrent.TimeUnit
 
@@ -56,4 +60,18 @@ class SakService(private val sakRepository: SakRepository) {
 
 
 
+    fun hentPersonForSak(sakIdentifikator: SakIdentifikator): ArenaSakPerson? {
+        return when(sakIdentifikator) {
+            is SakId -> hentPersonForSak(sakIdentifikator)
+            is Saksnummer -> hentPersonForSak(sakIdentifikator)
+        }
+    }
+
+    fun hentPersonForSak(sakId: SakId): ArenaSakPerson? {
+        TODO("IMPLEMENT ME")
+    }
+
+    fun hentPersonForSak(saksnummer: Saksnummer): ArenaSakPerson? {
+        TODO("IMPLEMENT ME")
+    }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TilgangService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/TilgangService.kt
@@ -1,0 +1,63 @@
+package no.nav.aap.arenaoppslag.service
+
+import no.nav.aap.arenaoppslag.modeller.SakIdentifikator
+import no.nav.aap.arenaoppslag.tilgangsmaskin.TilgangmaskinGateway
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
+
+class TilgangService(private val sakService: SakService, private val tilgangmaskinGateway: TilgangmaskinGateway) {
+    fun harTilgangTilPerson(brukerIdent: String, token: OidcToken): Authorized<String> {
+        return when(tilgangmaskinGateway.harTilgangTilPerson(brukerIdent, token)) {
+            true -> Authorized.HarTilgang(brukerIdent)
+            false -> Authorized.IkkeTilgang
+        }
+    }
+
+    fun harTilgangTilSak(sakIdentifikator: SakIdentifikator, token: OidcToken): Authorized<String> {
+        val person = sakService.hentPersonForSak(sakIdentifikator) ?: return Authorized.IkkeFunnet
+        return harTilgangTilPerson(person.fodselsnummer, token)
+    }
+}
+
+sealed class Authorized<out T> {
+    data class HarTilgang<T>(val item: T): Authorized<T>()
+    data object IkkeTilgang: Authorized<Nothing>()
+    data object IkkeFunnet: Authorized<Nothing>()
+
+    fun getOrNull(): T? {
+        if (this is HarTilgang) {
+            return item
+        }
+        return null
+    }
+
+    fun <G> map(block: (T) -> G): Authorized<G> = when (this) {
+        is HarTilgang -> HarTilgang(block(item))
+        IkkeTilgang -> IkkeTilgang
+        IkkeFunnet -> IkkeFunnet
+    }
+
+    fun <G : Any> mapNotNull(block: (T) -> G?): Authorized<G> = when (this) {
+        is HarTilgang -> when (val result = block(item)) {
+            null -> IkkeFunnet
+            else -> HarTilgang(result)
+        }
+        IkkeTilgang -> IkkeTilgang
+        IkkeFunnet -> IkkeFunnet
+    }
+
+    fun onError(block: () -> Unit): Authorized<T> {
+        if (this !is HarTilgang) {
+            block()
+        }
+        return this
+    }
+
+    suspend inline fun fold(suksess: suspend (T) -> Unit, ikkeFunnet: suspend () -> Unit, ikkeTilgang: suspend () -> Unit): Authorized<T> {
+        when (this) {
+            is HarTilgang -> suksess(item)
+            IkkeTilgang -> ikkeTilgang()
+            IkkeFunnet -> ikkeFunnet()
+        }
+        return this
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/tilgangsmaskin/TilgangmaskinGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/tilgangsmaskin/TilgangmaskinGateway.kt
@@ -1,0 +1,7 @@
+package no.nav.aap.arenaoppslag.tilgangsmaskin
+
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
+
+interface TilgangmaskinGateway {
+    fun harTilgangTilPerson(personIdentifikator: String, token: OidcToken): Boolean
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/tilgangsmaskin/TilgangmaskinGatewayMockImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/tilgangsmaskin/TilgangmaskinGatewayMockImpl.kt
@@ -1,0 +1,12 @@
+package no.nav.aap.arenaoppslag.tilgangsmaskin
+
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
+
+class TilgangmaskinGatewayMockImpl: TilgangmaskinGateway {
+    override fun harTilgangTilPerson(
+        personIdentifikator: String,
+        token: OidcToken
+    ): Boolean {
+        return true
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/util/Token.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/util/Token.kt
@@ -1,0 +1,14 @@
+package no.nav.aap.arenaoppslag.util
+
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.ApplicationCall
+import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.OidcToken
+import kotlin.text.split
+
+data class OidcToken(val token: String)
+
+public fun ApplicationCall.token(): OidcToken {
+    val token: String = requireNotNull(this.request.headers[HttpHeaders.Authorization]).split(" ")[1]
+
+    return OidcToken(token)
+}


### PR DESCRIPTION
Et forslag på hvordan man kunne gjort tilgangskontroll med fluent-API. Er ikke komplett, og en del mocket. Så dette bygger ikke. Mer ment for til diskusjon.

Tanken her er at man tilbyr 2 funksjoner på tilgang-service: `harTilgangTilPerson` og `harTilgangTilSak` som kan brukes for å i routes sjekke om man har tilgang til saken eller ikke. For å gjøre det lett å jobbe med returnerer den en `Authorized` tilbake som har et fluent-api, som gjør at man kan jobbe videre med verdiene OM man tilgang. Til slutt kan man ta en `fold` og returnere ulike responser basert på om man har `IkkeFunnet`, `HarTilgang` eller `IkkeTilgang`. 