### PR TITLE
Feat/eksponer detaljer om signifikant historikk

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -6,17 +6,21 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtak
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerResponse
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SisteUtbetalingerRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SisteUtbetalingerResponse
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.TellerRequest
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.modeller.SakId
 import no.nav.aap.arenaoppslag.modeller.Saksnummer
@@ -27,8 +31,9 @@ import no.nav.aap.arenaoppslag.service.SakService
 import no.nav.aap.arenaoppslag.service.TelleverkService
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SakerRequest as SakerRequestV1
 
-fun Route.historikk(historikkService: HistorikkService) {
+fun Route.historikk(historikkService: HistorikkService, personService: PersonService) {
     post("/person/signifikant-historikk") {
+        //TODO deprekert, skal fjernes
         logger.info("Sjekker om personens AAP-Arena-historikk er signifikant for saksbehandling i Kelvin")
         val request: SignifikanteSakerRequest = call.receive()
         val response: SignifikanteSakerResponse = historikkService.signifikanteSakerForPerson(
@@ -38,7 +43,35 @@ fun Route.historikk(historikkService: HistorikkService) {
         call.respond(response)
     }
 
+    post("/person/historikk/signifikant") {
+        logger.info("Sjekker om personens AAP-Arena-historikk er signifikant for saksbehandling i Kelvin")
+        val request: SignifikantHistorikkRequest = call.receive()
+        val personidentifikator = request.personidentifikator
+        val personId = personService.hentPersonId(personidentifikator)
+            ?: return@post call.respond(SignifikantHistorikkResponse.ingen)
+
+        val response: SignifikantHistorikkResponse = historikkService.signifikantHistorikk(
+            personId, request.virkningstidspunkt
+        )
+
+        call.respond(response)
+    }
+
+    post("/person/historikk") {
+        logger.info("Sjekker om person har historikk i AAP-Arena")
+        val request: HarHistorikkRequest = call.receive()
+        val personidentifikator = request.personidentifikator
+
+        val personId = personService.hentPersonId(personidentifikator)
+        val response = when (personId) {
+            null -> HarHistorikkResponse.nei
+            else -> HarHistorikkResponse.ja
+        }
+        call.respond(response)
+    }
+
     post("/person/eksisterer") {
+        //TODO deprekert, skal fjernes
         logger.info("Sjekker om person eksisterer i AAP-Arena")
         val request: SakerRequest = call.receive()
         val response: PersonEksistererIAAPArena =
@@ -89,7 +122,7 @@ fun Route.sak(sakService: SakService, posteringService: PosteringService, sakOgV
 
         val sakidentifikator = Saksnummer.fromString(sakid) ?: SakId.fromString(sakid)
         val sak = when (sakidentifikator) {
-            is SakId -> sakOgVedtakService.hentSakMedVedtak(saksId =  sakidentifikator)
+            is SakId -> sakOgVedtakService.hentSakMedVedtak(saksId = sakidentifikator)
             is Saksnummer -> sakOgVedtakService.hentSakMedVedtak(saksnummer = sakidentifikator)
             else -> null
         }
@@ -106,7 +139,7 @@ fun Route.sak(sakService: SakService, posteringService: PosteringService, sakOgV
         val sisteUtbetalingDato = posteringService.hentSisteAapUtbetalingForPerson(personId)
 
         logger.info("Henter saksdetaljer")
-        val response = sak.tilKontrakt( telleverk,kvoteHistorikk,sisteUtbetalingDato,maksdato)
+        val response = sak.tilKontrakt(telleverk, kvoteHistorikk, sisteUtbetalingDato, maksdato)
         call.respond(status = HttpStatusCode.OK, message = response)
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -99,7 +99,7 @@ fun Application.server(
 
     routes(datasource, pdlGateway)
 
-    warmup(datasource, pdlGateway)
+    warmup(datasource)
 
     monitor.subscribe(ApplicationStarted) { environment ->
         environment.log.info("ktor har startet opp.")
@@ -131,18 +131,14 @@ fun Application.server(
     }
 }
 
-private fun Application.warmup(
-    datasource: DataSource,
-    pdlGateway: IPdlGateway
-) {
+private fun Application.warmup(datasource: DataSource) {
     val historikkService = skapHistorikkService(datasource)
     val sakService = skapSakListeService(datasource)
-    val fiktivtFødselsnummer = "14224432837"
     val fiktivArenaPerson = PersonId(0xcafebabe.toInt())
 
     try {
         // Dette gjøres for å unngå at etter redeploy tar første query 2-3 sekund
-        historikkService.signifikanteSakerForPerson(setOf(fiktivtFødselsnummer), LocalDate.now())
+        historikkService.signifikantHistorikk(fiktivArenaPerson, LocalDate.now())
 
         // Generell innlasting av objektgraf og cache-opprettelse
         sakService.hentSakerForPerson(fiktivArenaPerson)
@@ -199,10 +195,10 @@ private fun skapPersonService(datasource: DataSource, pdlGateway: IPdlGateway): 
 
 private fun Application.routes(datasource: DataSource, pdlGateway: IPdlGateway) {
     val internService = skapInternService(datasource)
-    val historikkService = skapHistorikkService(datasource)
     val sakOgVedtakService = skapSakOgVedtakService(datasource)
     val telleverkService = skapTelleverkService(datasource)
     val personService = skapPersonService(datasource, pdlGateway)
+    val historikkService = skapHistorikkService(datasource)
     val sakListeService = skapSakListeService(datasource)
     val utbetalingService = skapUtbetalingService(datasource)
 
@@ -219,7 +215,7 @@ private fun Application.routes(datasource: DataSource, pdlGateway: IPdlGateway) 
             }
             route("/api/v1") {
                 // Eksterne APIer som kan brukes av andre. Brekkende endringer vil enten varsles eller versjoneres.
-                historikk(historikkService)
+                historikk(historikkService, personService)
                 telleverk(telleverkService, personService)
                 sakerForPerson(sakListeService, personService)
                 maksdato(sakListeService, personService)

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -2,6 +2,7 @@ package no.nav.aap.arenaoppslag.database
 
 import no.nav.aap.arenaoppslag.database.DbDato.fraDato
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.intellij.lang.annotations.Language
 import java.sql.Connection
 import java.sql.Date
@@ -12,11 +13,17 @@ import javax.sql.DataSource
 class HistorikkRepository(private val dataSource: DataSource) {
 
     fun hentAlleSignifikanteVedtakForPerson(
-        arenaPersonId: Int, søknadMottattPå: LocalDate
+        arenaPersonId: PersonId, søknadMottattPå: LocalDate
     ): List<ArenaVedtak> {
         return dataSource.connection.use { con ->
-            hentAlleSignifikanteVedtakForPerson(arenaPersonId, søknadMottattPå, con)
+            hentAlleSignifikanteVedtakForPerson(arenaPersonId.id, søknadMottattPå, con)
         }
+    }
+
+    fun hentAlleSignifikanteVedtakForPerson(
+        arenaPersonId: Int, søknadMottattPå: LocalDate
+    ): List<ArenaVedtak> {
+        return hentAlleSignifikanteVedtakForPerson(PersonId(arenaPersonId), søknadMottattPå)
     }
 
     companion object {

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Vedtak.kt
@@ -26,6 +26,7 @@ data class ArenaVedtak(
     val utfallkode: String?
 ) {
     fun tilKontrakt() = ArenaVedtakKontrakt(
+        sakId = sakId.toInt(),
         statusKode = statusKode,
         vedtaktypeKode = vedtaktypeKode,
         fraOgMed = fraOgMed,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/HistorikkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/HistorikkService.kt
@@ -8,17 +8,20 @@ import no.nav.aap.arenaoppslag.Metrics.registrerSignifikantEnkeltVedtak
 import no.nav.aap.arenaoppslag.Metrics.registrerSignifikantVedtak
 import no.nav.aap.arenaoppslag.database.HistorikkRepository
 import no.nav.aap.arenaoppslag.database.PersonRepository
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkResponse
 import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import java.time.LocalDate
 
 class HistorikkService(
-    private val personRepository: PersonRepository,
-    private val historikkRepository: HistorikkRepository
+    private val personRepository: PersonRepository, // fixme fjernes
+    private val historikkRepository: HistorikkRepository,
 ) {
 
     // Lagrer mappingen fødselsnr -> arena-personId. Bare treff i databasen lagres.
+    // TODO deprekert, fjern
     @Suppress("MagicNumber")
     private val personIdCache = Caffeine.newBuilder()
         .maximumSize(30_000)
@@ -29,6 +32,7 @@ class HistorikkService(
         CaffeineCacheMetrics.monitor(prometheus, personIdCache, "arenaoppslag_person_id")
     }
 
+    @Deprecated("Bruk signifikantHistorikk")
     fun signifikanteSakerForPerson(
         fodselsnummerene: Set<String>, virkningstidspunkt: LocalDate
     ): SignifikanteSakerResponse {
@@ -48,6 +52,24 @@ class HistorikkService(
         val arenaSakIdListe = sorterVedtak(signifikanteVedtak).map { it.sakId }.distinct()
 
         return SignifikanteSakerResponse(harSignifikantHistorikk, arenaSakIdListe)
+    }
+
+    fun signifikantHistorikk(
+        personId: PersonId,
+        virkningstidspunkt: LocalDate
+    ): SignifikantHistorikkResponse {
+        val signifikanteVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(
+            personId,
+            virkningstidspunkt
+        )
+        rapporterMetrikker(signifikanteVedtak)
+
+        val harSignifikantHistorikk = signifikanteVedtak.isNotEmpty()
+        val arenaSakIdListe = sorterVedtak(signifikanteVedtak)
+
+        return SignifikantHistorikkResponse(harSignifikantHistorikk, arenaSakIdListe.map {
+            it.tilKontrakt()
+        })
     }
 
     private fun rapporterMetrikker(vedtakene: List<ArenaVedtak>) {
@@ -78,6 +100,7 @@ class HistorikkService(
     }
 
     private fun hentPersonId(fodselsnummerene: Set<String>): Int? {
+        // TODO deprekert, fjern
         return fodselsnummerene.firstNotNullOfOrNull { personIdCache.getIfPresent(it) }
             ?: personRepository.hentPersonIdHvisEksisterer(fodselsnummerene)
                 ?.also { funnetPersonId ->

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/PersonService.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/service/PersonService.kt
@@ -1,5 +1,8 @@
 package no.nav.aap.arenaoppslag.service
 
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
+import no.nav.aap.arenaoppslag.Metrics.prometheus
 import no.nav.aap.arenaoppslag.database.PersonRepository
 import no.nav.aap.arenaoppslag.modeller.PersonId
 import no.nav.aap.arenaoppslag.pdl.IPdlGateway
@@ -8,7 +11,26 @@ class PersonService(
     private val personRepository: PersonRepository,
     private val pdlGateway: IPdlGateway,
 ) {
+    // Lagrer mappingen personidentifikator -> arena-personId. Bare treff i databasen lagres.
+    @Suppress("MagicNumber")
+    private val personIdCache = Caffeine.newBuilder()
+        .maximumSize(30_000)
+        .recordStats()
+        .build<String, PersonId>()
+
+    init {
+        CaffeineCacheMetrics.monitor(prometheus, personIdCache, "arenaoppslag_person_id")
+    }
+
     fun hentPersonId(personidentifikator: String): PersonId? {
+        return personIdCache.getIfPresent(personidentifikator)
+            ?: hentPersonIdUtenCache(personidentifikator)
+                ?.also { funnetPersonId ->
+                    personIdCache.put(personidentifikator, funnetPersonId)
+                }
+    }
+
+    private fun hentPersonIdUtenCache(personidentifikator: String): PersonId? {
         val alleIdenter = pdlGateway.hentAlleIdenterForPerson(personidentifikator)
             .map { it.ident }
             .toSet()

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/HistorikkApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/HistorikkApiTest.kt
@@ -2,10 +2,10 @@ package no.nav.aap.arenaoppslag
 
 import no.nav.aap.arenaoppslag.client.ArenaOppslagGateway.Companion.withTestServer
 import no.nav.aap.arenaoppslag.database.H2TestBase
-import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
-import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkResponse
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -19,24 +19,24 @@ class HistorikkApiTest : H2TestBase("flyway/minimumtest", "flyway/eksisterer") {
     @Test
     fun `Person har signifikant historikk i AAP-Arena`() {
         withTestServer(h2) { gateway ->
-            val kjentPerson: SignifikanteSakerResponse = gateway.personHarSignifikantAAPArenaHistorikk(
-                SignifikanteSakerRequest(
-                    personidentifikatorer = listOf(kjentPerson),
-                    virkningstidspunkt = LocalDateTime.now().minusDays(1).toLocalDate()
+            val ukjentPerson: SignifikantHistorikkResponse = gateway.harSignifikantHistorikk(
+                SignifikantHistorikkRequest(
+                    kjentPerson,
+                    LocalDateTime.now().minusDays(1).toLocalDate()
                 )
             )
 
-            assertThat(kjentPerson.harSignifikantHistorikk).isTrue
+            assertThat(ukjentPerson.harSignifikantHistorikk).isTrue
         }
     }
 
     @Test
     fun `Person har IKKE signifikant historikk i AAP-Arena`() {
         withTestServer(h2) { gateway ->
-            val ukjentPerson: SignifikanteSakerResponse = gateway.personHarSignifikantAAPArenaHistorikk(
-                SignifikanteSakerRequest(
-                    personidentifikatorer = listOf(ukjentPerson),
-                    virkningstidspunkt = LocalDateTime.now().minusDays(1).toLocalDate()
+            val ukjentPerson: SignifikantHistorikkResponse = gateway.harSignifikantHistorikk(
+                SignifikantHistorikkRequest(
+                    ukjentPerson,
+                    LocalDateTime.now().minusDays(1).toLocalDate()
                 )
             )
 
@@ -47,24 +47,16 @@ class HistorikkApiTest : H2TestBase("flyway/minimumtest", "flyway/eksisterer") {
     @Test
     fun `Person eksisterer i AAP-Arena, ja`() {
         withTestServer(h2) { gateway ->
-            val kjentPerson: PersonEksistererIAAPArena = gateway.hentPersonEksistererIAapContext(
-                SakerRequest(
-                    personidentifikatorer = listOf(kjentPerson)
-                )
-            )
-            assertThat(kjentPerson.eksisterer).isTrue
+            val kjentPerson: HarHistorikkResponse = gateway.harHistorikk(HarHistorikkRequest(kjentPerson))
+            assertThat(kjentPerson.harHistorikk).isTrue
         }
     }
 
     @Test
     fun `Person eksisterer i AAP-Arena, nei`() {
         withTestServer(h2) { gateway ->
-            val ukjentPerson: PersonEksistererIAAPArena = gateway.hentPersonEksistererIAapContext(
-                SakerRequest(
-                    personidentifikatorer = listOf(ukjentPerson)
-                )
-            )
-            assertThat(ukjentPerson.eksisterer).isFalse
+            val ukjentPerson: HarHistorikkResponse = gateway.harHistorikk(HarHistorikkRequest(ukjentPerson))
+            assertThat(ukjentPerson.harHistorikk).isFalse
         }
     }
 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
@@ -13,19 +13,20 @@ import no.nav.aap.arenaoppslag.TestConfig
 import no.nav.aap.arenaoppslag.TestConfig.jsonHttpClient
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtak
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoResponse
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkRequest
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.SignifikantHistorikkResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SisteUtbetalingerRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.SisteUtbetalingerResponse
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.VedtakForPersonRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.InternVedtakRequest
 import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderMed11_17Response
 import no.nav.aap.arenaoppslag.kontrakt.intern.PerioderResponse
-import no.nav.aap.arenaoppslag.kontrakt.intern.PersonEksistererIAAPArena
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakStatus
 import no.nav.aap.arenaoppslag.kontrakt.intern.SakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerRequest
-import no.nav.aap.arenaoppslag.kontrakt.intern.SignifikanteSakerResponse
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Maksimum
 import no.nav.aap.arenaoppslag.server
 import no.nav.aap.arenaoppslag.util.AzureTokenGen
@@ -55,20 +56,6 @@ class ArenaOppslagGateway(private val tokenProvider: AzureTokenGen, private val 
             >(
         "/intern/perioder/11-17", req
     ).getOrThrow()
-
-    suspend fun hentPersonEksistererIAapContext(
-        req: SakerRequest,
-    ): PersonEksistererIAAPArena =
-        gjørArenaOppslag<PersonEksistererIAAPArena, SakerRequest>(
-            "/api/v1/person/eksisterer", req
-        ).getOrThrow()
-
-    suspend fun personHarSignifikantAAPArenaHistorikk(
-        req: SignifikanteSakerRequest
-    ): SignifikanteSakerResponse =
-        gjørArenaOppslag<SignifikanteSakerResponse, SignifikanteSakerRequest>(
-            "/api/v1/person/signifikant-historikk", req
-        ).getOrThrow()
 
     suspend fun hentMaksdatoBySakIdListe(
         req: MaksdatoRequest
@@ -111,6 +98,20 @@ class ArenaOppslagGateway(private val tokenProvider: AzureTokenGen, private val 
     ): Maksimum = gjørArenaOppslag<Maksimum, InternVedtakRequest>(
         "/intern/maksimum", req
     ).getOrThrow()
+
+    suspend fun harHistorikk(
+        req: HarHistorikkRequest
+    ): HarHistorikkResponse =
+        gjørArenaOppslag<HarHistorikkResponse, HarHistorikkRequest>(
+            "/api/v1/person/historikk", req
+        ).getOrThrow()
+
+    suspend fun harSignifikantHistorikk(
+        req: SignifikantHistorikkRequest
+    ): SignifikantHistorikkResponse =
+        gjørArenaOppslag<SignifikantHistorikkResponse, SignifikantHistorikkRequest>(
+            "/api/v1/person/historikk/signifikant", req
+        ).getOrThrow()
 
     private suspend inline fun <reified T, reified V> gjørArenaOppslag(
         endepunkt: String, req: V

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepositoryTest.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.arenaoppslag.database
 
 import no.nav.aap.arenaoppslag.modeller.ArenaVedtak
+import no.nav.aap.arenaoppslag.modeller.PersonId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,7 +22,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     @Test
     fun `ingen signifikante vedtak for person som ikke finnes`() {
         val alleVedtak = historikkRepository.hentAlleSignifikanteVedtakForPerson(
-            arenaPersonId = 54601, /* finnes ikke */
+            PersonId(54601), /* finnes ikke */
             testDato,
         )
         assertThat(alleVedtak).isEmpty()
@@ -30,7 +31,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     @Test
     fun `ingen signifikante vedtak for person med kun veldig gamle vedtak`() {
         val testPerson = "kun_gamle"
-        val testPersonId = 992
+        val testPersonId = PersonId(992)
         val alleVedtak: List<ArenaVedtak> = vedtakRepository.hentVedtak(testPerson)
         assertThat(alleVedtak).hasSize(2)
 
@@ -41,7 +42,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     @Test
     fun `finner signifikante vedtak for person med kun nye vedtak`() {
         val testPersonFnr = "kun_nye"
-        val testPersonId = 996
+        val testPersonId = PersonId(996)
         val alleVedtak = vedtakRepository.hentVedtak(testPersonFnr)
         assertThat(alleVedtak).hasSize(3) // antall i vedtak-tabellen
 
@@ -57,7 +58,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     @Test
     fun `finner signifikante vedtak for person med både gamle og nye vedtak`() {
         val testPersonFnr = "blanding"
-        val testPersonId = 997
+        val testPersonId = PersonId(997)
         val alleVedtak = vedtakRepository.hentVedtak(testPersonFnr)
         assertThat(alleVedtak).hasSize(6)
 
@@ -68,7 +69,7 @@ class HistorikkRepositoryTest : H2TestBase("flyway/eksisterer") {
     @Test
     fun `Ingen signifikante vedtak for person med kun avslag på AA115`() {
         val testPersonFnr = "426282"
-        val testPersonId = 426282
+        val testPersonId = PersonId(426282)
         val alleVedtak = vedtakRepository.hentVedtak(testPersonFnr)
         assertThat(alleVedtak).hasSize(1)
 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/HistorikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/HistorikkServiceTest.kt
@@ -92,7 +92,6 @@ class HistorikkServiceTest {
         Assertions.assertThat(ikkeFunnet).isEqualTo(false)
     }
 
-
     @Test
     fun `personEksistererIAapArena bruker cachet verdi andre gang`() {
         val personIdentifikatorer = setOf("12345678901")

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/PersonServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/service/PersonServiceTest.kt
@@ -1,0 +1,93 @@
+package no.nav.aap.arenaoppslag.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.aap.arenaoppslag.database.PersonRepository
+import no.nav.aap.arenaoppslag.modeller.PersonId
+import no.nav.aap.arenaoppslag.pdl.IPdlGateway
+import no.nav.aap.arenaoppslag.pdl.PdlIdent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PersonServiceTest {
+
+    @Test
+    fun `hentPersonId bruker cache ved andre kall`() {
+        val personidentifikator = "12345678901"
+        val pdlIdent = "10987654321"
+        val pdlGateway = mockk<IPdlGateway>()
+        val personRepository = mockk<PersonRepository>()
+
+        every { pdlGateway.hentAlleIdenterForPerson(personidentifikator) } returns listOf(
+            PdlIdent(ident = personidentifikator, historisk = false, gruppe = "FOLKEREGISTERIDENT"),
+            PdlIdent(ident = pdlIdent, historisk = true, gruppe = "FOLKEREGISTERIDENT"),
+        )
+        every { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator, pdlIdent)) } returns PersonId(1)
+
+        val service = PersonService(personRepository, pdlGateway)
+
+        val firstCall = service.hentPersonId(personidentifikator)
+        val secondCall = service.hentPersonId(personidentifikator)
+
+        assertThat(firstCall).isEqualTo(PersonId(1))
+        assertThat(secondCall).isEqualTo(PersonId(1))
+        verify(exactly = 1) { pdlGateway.hentAlleIdenterForPerson(personidentifikator) }
+        verify(exactly = 1) { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator, pdlIdent)) }
+    }
+
+    @Test
+    fun `hentPersonId cacher ikke null-resultat og gjør nytt oppslag`() {
+        val personidentifikator = "12345678901"
+        val pdlGateway = mockk<IPdlGateway>()
+        val personRepository = mockk<PersonRepository>()
+
+        every { pdlGateway.hentAlleIdenterForPerson(personidentifikator) } returns listOf(
+            PdlIdent(ident = personidentifikator, historisk = false, gruppe = "FOLKEREGISTERIDENT"),
+        )
+        every { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator)) } returnsMany listOf(null, PersonId(2))
+
+        val service = PersonService(personRepository, pdlGateway)
+
+        val firstCall = service.hentPersonId(personidentifikator)
+        val secondCall = service.hentPersonId(personidentifikator)
+
+        assertThat(firstCall).isNull()
+        assertThat(secondCall).isEqualTo(PersonId(2))
+        verify(exactly = 2) { pdlGateway.hentAlleIdenterForPerson(personidentifikator) }
+        verify(exactly = 2) { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator)) }
+    }
+
+    @Test
+    fun `hentPersonId cacher uavhengig per personidentifikator`() {
+        val personidentifikator1 = "12345678901"
+        val personidentifikator2 = "10987654321"
+        val pdlGateway = mockk<IPdlGateway>()
+        val personRepository = mockk<PersonRepository>()
+
+        every { pdlGateway.hentAlleIdenterForPerson(personidentifikator1) } returns listOf(
+            PdlIdent(ident = personidentifikator1, historisk = false, gruppe = "FOLKEREGISTERIDENT"),
+        )
+        every { pdlGateway.hentAlleIdenterForPerson(personidentifikator2) } returns listOf(
+            PdlIdent(ident = personidentifikator2, historisk = false, gruppe = "FOLKEREGISTERIDENT"),
+        )
+        every { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator1)) } returns PersonId(1)
+        every { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator2)) } returns PersonId(2)
+
+        val service = PersonService(personRepository, pdlGateway)
+
+        val firstCallKey1 = service.hentPersonId(personidentifikator1)
+        val firstCallKey2 = service.hentPersonId(personidentifikator2)
+        val secondCallKey1 = service.hentPersonId(personidentifikator1)
+        val secondCallKey2 = service.hentPersonId(personidentifikator2)
+
+        assertThat(firstCallKey1).isEqualTo(PersonId(1))
+        assertThat(firstCallKey2).isEqualTo(PersonId(2))
+        assertThat(secondCallKey1).isEqualTo(PersonId(1))
+        assertThat(secondCallKey2).isEqualTo(PersonId(2))
+        verify(exactly = 1) { pdlGateway.hentAlleIdenterForPerson(personidentifikator1) }
+        verify(exactly = 1) { pdlGateway.hentAlleIdenterForPerson(personidentifikator2) }
+        verify(exactly = 1) { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator1)) }
+        verify(exactly = 1) { personRepository.hentPersonIdHvisEksisterer(setOf(personidentifikator2)) }
+    }
+}

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/Historikk.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/Historikk.kt
@@ -1,0 +1,31 @@
+package no.nav.aap.arenaoppslag.kontrakt.apiv1
+
+import java.time.LocalDate
+
+public data class HarHistorikkRequest(
+    val personidentifikator: String,
+)
+
+public data class SignifikantHistorikkRequest(
+    val personidentifikator: String,
+    val virkningstidspunkt: LocalDate, // datoen søknaden ble mottatt, feks. per post
+)
+
+public data class HarHistorikkResponse(
+    val harHistorikk: Boolean,
+) {
+    public companion object {
+        public val ja: HarHistorikkResponse = HarHistorikkResponse(true)
+        public val nei: HarHistorikkResponse = HarHistorikkResponse(false)
+    }
+}
+
+public data class SignifikantHistorikkResponse(
+    val harSignifikantHistorikk: Boolean,
+    val signifikanteVedtak: List<ArenaVedtak> // signifikante Arena-vedtak, sortert på dato, nyeste først
+) {
+    public companion object {
+        public val ingen: SignifikantHistorikkResponse = SignifikantHistorikkResponse(false, emptyList())
+    }
+    public fun saker(): List<Int> = signifikanteVedtak.map { it.sakId }
+}

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/VedtakResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/VedtakResponse.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 public data class VedtakForPersonRequest(val personidentifikator: String)
 
 public data class ArenaVedtak(
+    val sakId: Int,
     val statusKode: String,
     val vedtaktypeKode: String?,
     val fraOgMed: LocalDate?,

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/intern/InternRequest.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/intern/InternRequest.kt
@@ -16,6 +16,7 @@ public data class TellerRequest(
     val personidentifikator: String
 )
 
+@Deprecated("Bruk nytt endepunkt person/historikk/signifikant", level = DeprecationLevel.WARNING)
 public data class SignifikanteSakerRequest(
     val personidentifikatorer: List<String>,
     val virkningstidspunkt: LocalDate, // datoen søknaden ble mottatt, feks. per post

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/intern/InternResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/intern/InternResponse.kt
@@ -2,10 +2,12 @@ package no.nav.aap.arenaoppslag.kontrakt.intern
 
 import no.nav.aap.arenaoppslag.kontrakt.modeller.Periode
 
+@Deprecated("Bruk nytt endepunkt person/historikk", level = DeprecationLevel.WARNING)
 public data class PersonEksistererIAAPArena(
     val eksisterer: Boolean
 )
 
+@Deprecated("Bruk nytt endepunkt person/historikk/signifikant", level = DeprecationLevel.WARNING)
 public data class SignifikanteSakerResponse(
     val harSignifikantHistorikk: Boolean,
     val signifikanteSaker: List<String> // signifikante Arena-saker, sortert på dato, nyeste først


### PR DESCRIPTION
- Legger til cache på PersonService oppslag mot PDL, med tester
- Nye historikk-endepunkt som bruker PersonService, med tester. De oppgir informasjon om vedtakene som del av historikken
- Deprekerer eldre historikk-endepunkter

AAPM-121