### PR TITLE
Legg til GET /api/v1/sak/{sakid} og flytt ArenaSakPerson til kontrakt-modulen

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/ApiRoute.kt
@@ -117,7 +117,33 @@ fun Route.maksdato(sakService: SakService, personService: PersonService) {
     }
 }
 
-fun Route.sak(sakService: SakService, posteringService: PosteringService, sakOgVedtakService: SakOgVedtakService, telleverkService: TelleverkService, saksopplysningService: SaksopplysningService) {
+fun Route.sak(sakOgVedtakService: SakOgVedtakService) {
+    get("/sak/{sakid}") {
+        val sakid = call.parameters["sakid"]
+
+        if (sakid == null) {
+            logger.info("Sakid kan ikke være NULL")
+            return@get call.respond(HttpStatusCode.BadRequest)
+        }
+
+        val sakidentifikator = Saksnummer.fromString(sakid) ?: SakId.fromString(sakid)
+        val sak = when (sakidentifikator) {
+            is SakId -> sakOgVedtakService.hentSakMedVedtak(saksId = sakidentifikator)
+            is Saksnummer -> sakOgVedtakService.hentSakMedVedtak(saksnummer = sakidentifikator)
+            else -> null
+        }
+
+        if (sak == null) {
+            logger.info("Klarte ikke hente sak for saksnummer $sakid")
+            return@get call.respond(HttpStatusCode.NotFound)
+        }
+
+        logger.info("Henter sak med vedtak")
+        call.respond(status = HttpStatusCode.OK, message = sak.tilKontrakt())
+    }
+}
+
+fun Route.sakDetaljert(sakService: SakService, posteringService: PosteringService, sakOgVedtakService: SakOgVedtakService, telleverkService: TelleverkService, saksopplysningService: SaksopplysningService) {
     get("/sak/{sakid}/detaljert") {
         val sakid = call.parameters["sakid"]
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/App.kt
@@ -229,11 +229,12 @@ private fun Application.routes(datasource: DataSource, pdlGateway: IPdlGateway) 
                 maksdato(sakListeService, personService)
                 utbetalinger(utbetalingService, personService)
                 vedtakForPerson(sakOgVedtakService, personService)
+                sak(sakOgVedtakService)
             }
             route("/api/intern") {
                 // Nye interne APIer, disse skal kun konsumeres av team-aap-migrering sine applikasjoner
                 // Kontrakten på disse endepunktene kan endre seg helt uten forvarsel
-                sak(
+                sakDetaljert(
                     sakService = sakListeService,
                     posteringService = utbetalingService,
                     sakOgVedtakService = sakOgVedtakService,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
@@ -1,6 +1,8 @@
 package no.nav.aap.arenaoppslag.modeller
 
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakMedVedtakResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakOppsummeringKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakPersonKontrakt
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -125,6 +127,18 @@ data class ArenaSakMedVedtak(
         maksdato = maksdato,
         sisteUtbetalingDato = sisteUtbetalingDato,
     )
+
+    fun tilKontrakt() = ArenaSakMedVedtakResponse(
+        sakId = sakId,
+        opprettetAar = opprettetAar,
+        lopenr = lopenr,
+        person = person.tilKontrakt(),
+        statuskode = statuskode,
+        statusnavn = statusnavn,
+        registrertDato = registrertDato,
+        avsluttetDato = avsluttetDato,
+        vedtak = vedtak.map { it.tilKontrakt() },
+    )
 }
 
 data class ArenaSakPerson(
@@ -132,7 +146,14 @@ data class ArenaSakPerson(
     val fodselsnummer: String,
     val fornavn: String,
     val etternavn: String,
-)
+) {
+    fun tilKontrakt() = ArenaSakPersonKontrakt(
+        personId = personId,
+        fodselsnummer = fodselsnummer,
+        fornavn = fornavn,
+        etternavn = etternavn,
+    )
+}
 
 fun ArenaSak.toArenaSakMedVedtak(vedtak: List<ArenaVedtakMedDetaljer>) =
     ArenaSakMedVedtak(

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/modeller/Sak.kt
@@ -2,7 +2,7 @@ package no.nav.aap.arenaoppslag.modeller
 
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakMedVedtakResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakOppsummeringKontrakt
-import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakPersonKontrakt
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakPerson as ArenaSakPersonKontrakt
 import java.time.LocalDate
 import java.time.LocalDateTime
 

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/SakApiTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/SakApiTest.kt
@@ -1,0 +1,45 @@
+package no.nav.aap.arenaoppslag
+
+import no.nav.aap.arenaoppslag.client.ArenaOppslagGateway.Companion.withTestServer
+import no.nav.aap.arenaoppslag.database.H2TestBase
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakMedVedtakResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SakApiTest : H2TestBase("flyway/minimumtest") {
+
+    @Test
+    fun `Henter sak med vedtak for kjent sakId`() {
+        withTestServer(h2) { gateway ->
+            val sak: ArenaSakMedVedtakResponse = gateway.hentSak("1")
+
+            assertThat(sak.sakId).isEqualTo("1")
+            assertThat(sak.opprettetAar).isEqualTo(2021)
+            assertThat(sak.lopenr).isEqualTo(1)
+            assertThat(sak.statuskode).isEqualTo("AKTIV")
+            assertThat(sak.person.fodselsnummer).isEqualTo("123")
+            assertThat(sak.vedtak).hasSize(1)
+        }
+    }
+
+    @Test
+    fun `Henter sak med vedtak via saksnummer`() {
+        withTestServer(h2) { gateway ->
+            val sak: ArenaSakMedVedtakResponse = gateway.hentSak("2021-1")
+
+            assertThat(sak.sakId).isEqualTo("1")
+            assertThat(sak.vedtak).hasSize(1)
+        }
+    }
+
+    @Test
+    fun `Returnerer 404 for ukjent sakId`() {
+        withTestServer(h2) { gateway ->
+            val statusKode = runCatching { gateway.hentSak("99999") }
+                .exceptionOrNull()
+                ?.message
+
+            assertThat(statusKode).contains("404")
+        }
+    }
+}

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
@@ -13,6 +13,7 @@ import no.nav.aap.arenaoppslag.TestConfig
 import no.nav.aap.arenaoppslag.TestConfig.jsonHttpClient
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtak
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaVedtakMedDetaljer
+import no.nav.aap.arenaoppslag.kontrakt.apiv1.ArenaSakMedVedtakResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkRequest
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.HarHistorikkResponse
 import no.nav.aap.arenaoppslag.kontrakt.apiv1.MaksdatoMedVedtakResponse
@@ -120,6 +121,15 @@ class ArenaOppslagGateway(private val tokenProvider: AzureTokenGen, private val 
         gjørArenaOppslag<SignifikantHistorikkResponse, SignifikantHistorikkRequest>(
             "/api/v1/person/historikk/signifikant", req
         ).getOrThrow()
+
+    suspend fun hentSak(sakId: String): ArenaSakMedVedtakResponse {
+        val token = tokenProvider.generate()
+        val arenaResponse = httpClient.get("/api/v1/sak/$sakId") {
+            accept(ContentType.Application.Json)
+            bearerAuth(token)
+        }
+        return objectMapper.readValue(arenaResponse.bodyAsText())
+    }
 
     private suspend inline fun <reified T, reified V> gjørArenaOppslag(
         endepunkt: String, req: V

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakResponse.kt
@@ -2,7 +2,7 @@ package no.nav.aap.arenaoppslag.kontrakt.apiv1
 
 import java.time.LocalDateTime
 
-public data class ArenaSakPersonKontrakt(
+public data class ArenaSakPerson(
     val personId: Int,
     val fodselsnummer: String,
     val fornavn: String,
@@ -13,7 +13,7 @@ public data class ArenaSakMedVedtakResponse(
     val sakId: String,
     val opprettetAar: Int,
     val lopenr: Int,
-    val person: ArenaSakPersonKontrakt,
+    val person: ArenaSakPerson,
     val statuskode: String,
     val statusnavn: String,
     val registrertDato: LocalDateTime,

--- a/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakResponse.kt
+++ b/kontrakt/src/main/kotlin/no/nav/aap/arenaoppslag/kontrakt/apiv1/SakResponse.kt
@@ -1,0 +1,22 @@
+package no.nav.aap.arenaoppslag.kontrakt.apiv1
+
+import java.time.LocalDateTime
+
+public data class ArenaSakPersonKontrakt(
+    val personId: Int,
+    val fodselsnummer: String,
+    val fornavn: String,
+    val etternavn: String,
+)
+
+public data class ArenaSakMedVedtakResponse(
+    val sakId: String,
+    val opprettetAar: Int,
+    val lopenr: Int,
+    val person: ArenaSakPersonKontrakt,
+    val statuskode: String,
+    val statusnavn: String,
+    val registrertDato: LocalDateTime,
+    val avsluttetDato: LocalDateTime?,
+    val vedtak: List<ArenaVedtakMedDetaljer>,
+)


### PR DESCRIPTION
**Bakgrunn for endringen:**
I Kelvin trenger jeg et endepunkt for å kunne hente en sak gitt et saksnummer eller en sakid. For min case er saksnummer relevant, siden saksbehandler skal skrive inn en saksnummer og så skal vi sjekke om dette er en eksisterende sak. Men informasjonen vi skal vise inneholder blandt annet navnet på brukeren det gjelder. Derfor kan ikke noen av de eksisterende sak-kontraktene brukes og jeg innførte derfor en egen sak-kontrakt som er veldig lik den på detaljert-endepunktet bare uten alt av denne ekstra-informasjonen som er mer enn sak og vedtak.

**Sikkerhet:**
Vi har ikke tilgangskontroll via tilgangsmaskin enda, så sjekker ikke om saksbehandler har tilgang til personen vi returnerer data på her. Dette blir gjort i api-intern så sikkerheten er bevart, men som tidligere diskutert er det nok fint om dette gjøres også i denne applikasjonen. Så dette er et endepunkt som trenger samme sjekken som de andre når vi kommer så langt som å implementere det.

**Følgende endringer er gjort:**
- Ny kontrakt-type ArenaSakPersonKontrakt i kontrakt/apiv1/SakResponse.kt, erstatter den interne ArenaSakPerson-klassen som er slettet
- Ny kontrakt-type ArenaSakMedVedtakResponse: sak med vedtak uten detaljert-feltene
- Ny tilKontrakt() uten parametere på ArenaSakMedVedtak som mapper til ArenaSakMedVedtakResponse
- Nytt endepunkt GET /api/v1/sak/{sakid} (Route.sak) — støtter både sakId og saksnummer
- Gammel Route.sak omdøpt til Route.sakDetaljert for å tydeliggjøre forskjellen
- Integrasjonstest SakApiTest med tre testtilfeller