### PR TITLE
feat: update endpoint paths for manuell fordelingsgrunnlag

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/InternRoute.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/InternRoute.kt
@@ -69,7 +69,7 @@ fun Route.manuellFordelingsgrunnlag(
     manuellFordelingsgrunnlagService: ManuellFordelingsgrunnlagService,
     personService: PersonService,
 ) {
-    post("/person/manuell-fordelingsgrunnlag") {
+    post("/manuell-fordelingsgrunnlag") {
         val request: ManuellFordelingsgrunnlagRequest = call.receive()
 
         val personId = personService.hentPersonId(request.personidentifikator)

--- a/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
+++ b/app/src/test/kotlin/no/nav/aap/arenaoppslag/client/ArenaOppslagGateway.kt
@@ -79,7 +79,7 @@ class ArenaOppslagGateway(private val tokenProvider: AzureTokenGen, private val 
         req: ManuellFordelingsgrunnlagRequest
     ): ManuellFordelingsgrunnlagResponse =
         gjørArenaOppslag<ManuellFordelingsgrunnlagResponse, ManuellFordelingsgrunnlagRequest>(
-            "/intern/person/manuell-fordelingsgrunnlag", req
+            "/intern/manuell-fordelingsgrunnlag", req
         ).getOrThrow()
 
     suspend fun hentVedtakForPerson(


### PR DESCRIPTION
Likte ikke navnet når jeg implenterte consumeren i api-intern. Blir likt med andre endpunkt