### PR TITLE
Korriger maksdato-spørring

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -35,6 +35,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
             sak_id, 
             aar,
             lopenrvedtak,
+            lopenrsak,
             vedtakstatuskode, 
             vedtaktypekode, 
             fra_dato, 
@@ -51,20 +52,9 @@ class HistorikkRepository(private val dataSource: DataSource) {
           AND NOT (fra_dato > til_dato AND (til_dato IS NOT NULL AND fra_dato IS NOT NULL)) -- filtrer ut ugyldiggjorte vedtak
           AND ((fra_dato IS NOT NULL OR til_dato IS NOT NULL) OR vedtakstatuskode IN ('OPPRE', 'MOTAT', 'REGIS', 'INNST')) -- filtrer ut etterregistrerte vedtak, men behold vedtak som er under behandling
           AND ( 
-                (vedtaktypekode IN ('O','E','G') AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
+                ((vedtaktypekode IN ('O','E','G') OR (vedtaktypekode = 'S' and v.til_dato IS NOT NULL)) AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
                   OR
-                (vedtaktypekode = 'S' AND
-                     -- Det skal ikke finnes et gjenopptak etter stansen 
-                    NOT EXISTS(
-                         SELECT vedtak_id from vedtak vv where
-                            vv.sak_id = v.sak_id -- innad i samme sak, for raskere spørring
-                            AND (v.utfallkode IS NULL OR v.utfallkode != 'AVBRUTT')
-                            AND v.rettighetkode = 'AAP'
-                            AND vv.reg_dato > v.reg_dato -- et nyere vedtak
-                            AND vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                            AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
-                    )
-                AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
+                (vedtaktypekode = 'S' AND til_dato IS NULL AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
           AND NOT (utfallkode = 'NEI' AND til_dato IS NULL AND (fra_dato IS NOT NULL AND fra_dato <= ?)) -- utfallkode NEI vil ha åpen til_dato, så ekskluder disse når de er gamle
         """.trimIndent()
@@ -77,6 +67,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
             sak_id, 
             aar,
             lopenrvedtak,
+            lopenrsak,
             vedtakstatuskode, 
             vedtaktypekode, 
             fra_dato, 
@@ -93,22 +84,10 @@ class HistorikkRepository(private val dataSource: DataSource) {
           AND NOT (fra_dato > til_dato AND (til_dato IS NOT NULL AND fra_dato IS NOT NULL)) -- filtrer ut ugyldiggjorte vedtak
           AND ((fra_dato IS NOT NULL OR til_dato IS NOT NULL) OR vedtakstatuskode IN ('OPPRE', 'MOTAT', 'REGIS', 'INNST')) -- filtrer ut etterregistrerte vedtak, men behold vedtak som er under behandling
           AND ( 
-                (vedtaktypekode IN ('O','E','G') AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
+                ( (vedtaktypekode IN ('O','E','G') OR (vedtaktypekode = 'S' and v.til_dato IS NOT NULL)) AND (til_dato IS NULL OR til_dato >= ?) ) -- vanlig tidsbuffer
                   OR
-                (vedtaktypekode = 'S' AND 
-                    -- Det skal ikke finnes et gjenopptak etter stansen 
-                    NOT EXISTS(
-                         SELECT vedtak_id from vedtak vv where
-                            vv.sak_id = v.sak_id -- innad i samme sak, for raskere spørring
-                            AND v.rettighetkode = 'AA115'
-                            AND (v.utfallkode IS NULL OR v.utfallkode != 'AVBRUTT')
-                            AND vv.reg_dato > v.reg_dato -- et nyere vedtak
-                            AND vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                            AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
-                    )
-                AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
+                (vedtaktypekode = 'S' AND til_dato IS NULL AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
-              
           AND NOT (utfallkode = 'NEI' AND til_dato IS NULL) -- bruker fikk avslag
         """.trimIndent()
 
@@ -122,6 +101,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
             v.sak_id,
             v.aar,
             v.lopenrvedtak,
+            v.lopenrsak,
             vedtakstatuskode,
             vedtaktypekode,
             CAST(NULL AS DATE)                    AS fra_dato,
@@ -152,6 +132,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
             v.sak_id,
             v.aar,
             v.lopenrvedtak,
+            v.lopenrsak,
             vedtakstatuskode,
             vedtaktypekode,
             CAST(NULL AS DATE)                    AS fra_dato,

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -53,8 +53,14 @@ class HistorikkRepository(private val dataSource: DataSource) {
           AND ( 
                 (vedtaktypekode IN ('O','E','G') AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
                   OR
-                (vedtaktypekode = 'S' AND NOT EXISTS(select vedtak_id from vedtak vv where 
-                     vv.lopenrvedtak > v.lopenrvedtak and vv.vedtak_id=v.vedtak_id_relatert and vv.vedtaktypekode !='S')
+                (vedtaktypekode = 'S' AND
+                     -- det skal ikke finnes et gjenopptak etter stansen 
+                    NOT EXISTS(
+                         SELECT vedtak_id from vedtak vv where
+                            vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
+                            and vv.vedtak_id=v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                            and vv.vedtaktypekode !='S' -- og ikke er stans selv
+                         )
                 AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
           AND NOT (utfallkode = 'NEI' AND til_dato IS NULL AND (fra_dato IS NOT NULL AND fra_dato <= ?)) -- utfallkode NEI vil ha åpen til_dato, så ekskluder disse når de er gamle

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -58,8 +58,8 @@ class HistorikkRepository(private val dataSource: DataSource) {
                     NOT EXISTS(
                          SELECT vedtak_id from vedtak vv where
                             vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
-                            and vv.vedtak_id=v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                            and vv.vedtaktypekode !='S' -- og ikke er stans selv
+                            and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                            and vv.vedtaktypekode != 'S' -- og ikke er stans selv
                          )
                 AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -54,13 +54,13 @@ class HistorikkRepository(private val dataSource: DataSource) {
                 (vedtaktypekode IN ('O','E','G') AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
                   OR
                 (vedtaktypekode = 'S' AND
-                     -- det skal ikke finnes et gjenopptak etter stansen 
+                     -- Det skal ikke finnes et gjenopptak etter stansen 
                     NOT EXISTS(
                          SELECT vedtak_id from vedtak vv where
                             vv.reg_dato > v.reg_dato -- et nyere vedtak
                             and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
                             and vv.vedtaktypekode != 'S' -- og ikke er stans selv
-                         )
+                    )
                 AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
           AND NOT (utfallkode = 'NEI' AND til_dato IS NULL AND (fra_dato IS NOT NULL AND fra_dato <= ?)) -- utfallkode NEI vil ha åpen til_dato, så ekskluder disse når de er gamle
@@ -92,10 +92,17 @@ class HistorikkRepository(private val dataSource: DataSource) {
           AND ( 
                 (vedtaktypekode IN ('O','E','G') AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
                   OR
-                (vedtaktypekode = 'S' AND NOT EXISTS(select vedtak_id from vedtak vv where 
-                     vv.reg_dato > v.reg_dato and vv.vedtak_id=v.vedtak_id_relatert and vv.vedtaktypekode !='S')
-                     AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
+                (vedtaktypekode = 'S' AND 
+                    -- Det skal ikke finnes et gjenopptak etter stansen 
+                    NOT EXISTS(
+                         SELECT vedtak_id from vedtak vv where
+                            vv.reg_dato > v.reg_dato -- et nyere vedtak
+                            and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                            and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                    )
+                AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
+              
           AND NOT (utfallkode = 'NEI' AND til_dato IS NULL) -- bruker fikk avslag
         """.trimIndent()
 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -57,9 +57,12 @@ class HistorikkRepository(private val dataSource: DataSource) {
                      -- Det skal ikke finnes et gjenopptak etter stansen 
                     NOT EXISTS(
                          SELECT vedtak_id from vedtak vv where
-                            vv.reg_dato > v.reg_dato -- et nyere vedtak
-                            and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                            and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                            vv.sak_id = v.sak_id -- innad i samme sak, for raskere spørring
+                            AND (v.utfallkode IS NULL OR v.utfallkode != 'AVBRUTT')
+                            AND v.rettighetkode = 'AAP'
+                            AND vv.reg_dato > v.reg_dato -- et nyere vedtak
+                            AND vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                            AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
                     )
                 AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
@@ -96,9 +99,12 @@ class HistorikkRepository(private val dataSource: DataSource) {
                     -- Det skal ikke finnes et gjenopptak etter stansen 
                     NOT EXISTS(
                          SELECT vedtak_id from vedtak vv where
-                            vv.reg_dato > v.reg_dato -- et nyere vedtak
-                            and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                            and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                            vv.sak_id = v.sak_id -- innad i samme sak, for raskere spørring
+                            AND v.rettighetkode = 'AA115'
+                            AND (v.utfallkode IS NULL OR v.utfallkode != 'AVBRUTT')
+                            AND vv.reg_dato > v.reg_dato -- et nyere vedtak
+                            AND vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                            AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
                     )
                 AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
@@ -182,7 +188,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
                     selectKunRelevante11_5Vedtak,
                     selectKunRelevanteKlager,
                     selectKunRelevanteAnker,
-                ).joinToString("\nUNION ALL\n") + "ORDER BY aar DESC, lopenrvedtak DESC"
+                ).joinToString("\nUNION ALL\n") + "ORDER BY aar DESC, lopenrsak DESC, lopenrvedtak DESC"
 
             connection.createParameterizedQuery(query).use { preparedStatement ->
                 var p = 1 // parameter-indeks

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/HistorikkRepository.kt
@@ -57,7 +57,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
                      -- det skal ikke finnes et gjenopptak etter stansen 
                     NOT EXISTS(
                          SELECT vedtak_id from vedtak vv where
-                            vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
+                            vv.reg_dato > v.reg_dato -- et nyere vedtak
                             and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
                             and vv.vedtaktypekode != 'S' -- og ikke er stans selv
                          )
@@ -93,7 +93,7 @@ class HistorikkRepository(private val dataSource: DataSource) {
                 (vedtaktypekode IN ('O','E','G') AND (til_dato IS NULL OR til_dato >= ?)) -- vanlig tidsbuffer
                   OR
                 (vedtaktypekode = 'S' AND NOT EXISTS(select vedtak_id from vedtak vv where 
-                     vv.lopenrvedtak > v.lopenrvedtak and vv.vedtak_id=v.vedtak_id_relatert and vv.vedtaktypekode !='S')
+                     vv.reg_dato > v.reg_dato and vv.vedtak_id=v.vedtak_id_relatert and vv.vedtaktypekode !='S')
                      AND (fra_dato IS NULL OR fra_dato >= ?)) -- ekstra tidsbuffer for Stans, som bare har fra_dato
               )
           AND NOT (utfallkode = 'NEI' AND til_dato IS NULL) -- bruker fikk avslag

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -210,13 +210,14 @@ class SakRepository(private val dataSource: DataSource) {
                             -- Ekskluder slike gamle stans-vedtak: 
                             AND NOT EXISTS(
                                  SELECT vedtak_id FROM vedtak vv WHERE
-                                    v.person_id = vv.person_id -- for samme person
-                                    AND v.rettighetkode = 'AAP'
-                                    AND v.utfallkode = 'JA'
-                                    AND v.vedtakstatuskode IN ('IVERK','AVSLU')
+                                    vv.person_id = v.person_id -- for samme person
+                                    -- Samme begrensning som hovedspørringen:
+                                    AND vv.rettighetkode = 'AAP'
+                                    AND vv.utfallkode = 'JA'
+                                    AND vv.vedtakstatuskode IN ('IVERK','AVSLU')
+                                    -- Et nyere vedtak erstatter denne stansen:
                                     AND vv.vedtak_id > v.vedtak_id -- et nyere vedtak
                                     AND (vv.fra_dato IS NOT NULL AND v.fra_dato IS NOT NULL AND vv.fra_dato > v.fra_dato) -- med nyere fra_dato
-                                    AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
                             )
                             )) 
                         -- ignorer ugyldiggjorte vedtak og etterregistrerte vedtak:

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -198,7 +198,7 @@ class SakRepository(private val dataSource: DataSource) {
                         v.aktfasekode,
                         v.fra_dato,
                         v.til_dato,
-                        ROW_NUMBER() OVER (PARTITION BY v.person_id ORDER BY v.til_dato DESC NULLS FIRST, v.aar DESC, v.lopenrvedtak DESC) as rn
+                        ROW_NUMBER() OVER (PARTITION BY v.person_id ORDER BY v.til_dato DESC NULLS FIRST, v.aar DESC, v.lopenrsak DESC, v.lopenrvedtak DESC) as rn
                     FROM vedtak v
                     WHERE v.person_id = ?
                         AND v.rettighetkode = 'AAP'

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -209,14 +209,14 @@ class SakRepository(private val dataSource: DataSource) {
                             -- Det skal ikke finnes et gjenopptak etter stansen                          
                             AND NOT EXISTS(
                                  SELECT vedtak_id FROM vedtak vv WHERE
-                                    vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
+                                    vv.reg_dato > v.reg_dato -- et nyere vedtak
                                     and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
                                     and vv.vedtaktypekode != 'S' -- og ikke er stans selv
                             )
                             -- Det skal heller ikke finnes vedtak med en nyere fra_dato enn stans-vedtaket
                             AND NOT EXISTS(
                                  SELECT vedtak_id FROM vedtak vv WHERE
-                                    vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
+                                    vv.reg_dato > v.reg_dato -- et nyere vedtak
                                     and (vv.fra_dato IS NOT NULL and v.fra_dato IS NOT NULL and vv.fra_dato > v.fra_dato) -- med nyere fra_dato
                                     and vv.vedtaktypekode != 'S' -- og ikke er stans selv
                             )

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -198,14 +198,29 @@ class SakRepository(private val dataSource: DataSource) {
                         v.aktfasekode,
                         v.fra_dato,
                         v.til_dato,
-                        ROW_NUMBER() OVER (PARTITION BY v.person_id ORDER BY v.til_dato DESC NULLS FIRST, v.aar DESC, v.lopenrsak DESC, v.lopenrvedtak DESC) as rn
+                        ROW_NUMBER() OVER (PARTITION BY v.person_id ORDER BY v.til_dato DESC NULLS FIRST, v.vedtak_id DESC) as rn
                     FROM vedtak v
                     WHERE v.person_id = ?
                         AND v.rettighetkode = 'AAP'
                         AND v.utfallkode = 'JA'
                         AND v.vedtakstatuskode IN ('IVERK','AVSLU')
                         -- krev til_dato, utenom for stansede vedtak som ikke er erstattet av et nytt vedtak
-                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode='S' AND v.vedtak_id_relatert is NULL)) 
+                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode = 'S'
+                            -- Det skal ikke finnes et gjenopptak etter stansen                          
+                            AND NOT EXISTS(
+                                 SELECT vedtak_id FROM vedtak vv WHERE
+                                    vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
+                                    and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                                    and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                            )
+                            -- Det skal heller ikke finnes vedtak med en nyere fra_dato enn stans-vedtaket
+                            AND NOT EXISTS(
+                                 SELECT vedtak_id FROM vedtak vv WHERE
+                                    vv.lopenrvedtak > v.lopenrvedtak -- et nyere vedtak
+                                    and (vv.fra_dato IS NOT NULL and v.fra_dato IS NOT NULL and vv.fra_dato > v.fra_dato) -- med nyere fra_dato
+                                    and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                            )
+                            )) 
                         -- ignorer ugyldiggjorte vedtak og etterregistrerte vedtak:
                         AND v.fra_dato IS NOT NULL
                         AND NOT ((v.fra_dato IS NOT NULL and v.til_dato IS NOT NULL) AND v.fra_dato > v.til_dato) 

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -203,28 +203,18 @@ class SakRepository(private val dataSource: DataSource) {
                         AND v.rettighetkode = 'AAP'
                         AND v.utfallkode = 'JA'
                         AND v.vedtakstatuskode IN ('IVERK','AVSLU')
-                        -- krev til_dato, utenom for stansede vedtak som ikke er erstattet av et nytt vedtak
-                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode = 'S'
-                            -- Det skal ikke finnes et gjenopptak etter stansen                          
+                        -- Krev til_dato, utenom for stansede vedtak som ikke er erstattet av et nytt vedtak
+                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode = 'S' AND v.til_dato IS NULL 
+                            -- Gjenopptak fører til at stansede vedtak får satt til_dato.                          
+                            -- En gammel sak kan ha endt med et stans-vedtak, men personen har en løpende ny sak. 
+                            -- Ekskluder slike gamle stans-vedtak: 
                             AND NOT EXISTS(
                                  SELECT vedtak_id FROM vedtak vv WHERE
-                                    vv.sak_id = v.sak_id -- innad i samme sak, for raskere spørring
-                                    AND v.rettighetkode = 'AAP'
-                                    AND v.utfallkode = 'JA'
-                                    AND v.vedtakstatuskode IN ('IVERK','AVSLU')
-                                    AND vv.reg_dato > v.reg_dato -- et nyere vedtak
-                                    AND vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                                    AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
-                            )
-                            -- Det skal heller ikke finnes vedtak med en nyere fra_dato enn stans-vedtaket
-                            AND NOT EXISTS(
-                                 SELECT vedtak_id FROM vedtak vv WHERE
-                                    -- Vi inkluderer vedtak i nyere saker, ettersom stans kan henge igjen i gammel sak
                                     v.person_id = vv.person_id -- for samme person
                                     AND v.rettighetkode = 'AAP'
                                     AND v.utfallkode = 'JA'
                                     AND v.vedtakstatuskode IN ('IVERK','AVSLU')
-                                    AND vv.reg_dato > v.reg_dato -- et nyere vedtak
+                                    AND vv.vedtak_id > v.vedtak_id -- et nyere vedtak
                                     AND (vv.fra_dato IS NOT NULL AND v.fra_dato IS NOT NULL AND vv.fra_dato > v.fra_dato) -- med nyere fra_dato
                                     AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
                             )

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -198,7 +198,7 @@ class SakRepository(private val dataSource: DataSource) {
                         v.aktfasekode,
                         v.fra_dato,
                         v.til_dato,
-                        ROW_NUMBER() OVER (PARTITION BY v.person_id ORDER BY v.til_dato DESC NULLS LAST, v.vedtak_id DESC) as rn
+                        ROW_NUMBER() OVER (PARTITION BY v.person_id ORDER BY v.til_dato DESC NULLS FIRST, v.aar DESC, v.lopenrvedtak DESC) as rn
                     FROM vedtak v
                     WHERE v.person_id = ?
                         AND v.rettighetkode = 'AAP'
@@ -206,6 +206,8 @@ class SakRepository(private val dataSource: DataSource) {
                         AND v.vedtakstatuskode IN ('IVERK','AVSLU')
                         -- ignorer ugyldiggjorte vedtak og etterregistrerte vedtak:
                         AND v.fra_dato IS NOT NULL
+                        -- stansvedtak kan ha null til_dato:
+                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode='S' AND v.vedtak_id_relatert is NULL)) 
                         AND NOT ((v.fra_dato IS NOT NULL and v.til_dato IS NOT NULL) AND v.fra_dato > v.til_dato) 
                 ) WHERE rn = 1
             )

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -186,7 +186,6 @@ class SakRepository(private val dataSource: DataSource) {
                 sak.sakstatuskode, sakstatus.sakstatusnavn
         """.trimIndent()
 
-
         @Language("OracleSql")
         internal val selectVedtakMedNyesteMaxdatoForPerson = """
             -- Hent først siste vedtak
@@ -209,16 +208,25 @@ class SakRepository(private val dataSource: DataSource) {
                             -- Det skal ikke finnes et gjenopptak etter stansen                          
                             AND NOT EXISTS(
                                  SELECT vedtak_id FROM vedtak vv WHERE
-                                    vv.reg_dato > v.reg_dato -- et nyere vedtak
-                                    and vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
-                                    and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                                    vv.sak_id = v.sak_id -- innad i samme sak, for raskere spørring
+                                    AND v.rettighetkode = 'AAP'
+                                    AND v.utfallkode = 'JA'
+                                    AND v.vedtakstatuskode IN ('IVERK','AVSLU')
+                                    AND vv.reg_dato > v.reg_dato -- et nyere vedtak
+                                    AND vv.vedtak_id = v.vedtak_id_relatert -- som er relatert til dette stans-vedtaket
+                                    AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
                             )
                             -- Det skal heller ikke finnes vedtak med en nyere fra_dato enn stans-vedtaket
                             AND NOT EXISTS(
                                  SELECT vedtak_id FROM vedtak vv WHERE
-                                    vv.reg_dato > v.reg_dato -- et nyere vedtak
-                                    and (vv.fra_dato IS NOT NULL and v.fra_dato IS NOT NULL and vv.fra_dato > v.fra_dato) -- med nyere fra_dato
-                                    and vv.vedtaktypekode != 'S' -- og ikke er stans selv
+                                    -- Vi inkluderer vedtak i nyere saker, ettersom stans kan henge igjen i gammel sak
+                                    v.person_id = vv.person_id -- for samme person
+                                    AND v.rettighetkode = 'AAP'
+                                    AND v.utfallkode = 'JA'
+                                    AND v.vedtakstatuskode IN ('IVERK','AVSLU')
+                                    AND vv.reg_dato > v.reg_dato -- et nyere vedtak
+                                    AND (vv.fra_dato IS NOT NULL AND v.fra_dato IS NOT NULL AND vv.fra_dato > v.fra_dato) -- med nyere fra_dato
+                                    AND vv.vedtaktypekode != 'S' -- og ikke er stans selv
                             )
                             )) 
                         -- ignorer ugyldiggjorte vedtak og etterregistrerte vedtak:
@@ -237,6 +245,7 @@ class SakRepository(private val dataSource: DataSource) {
             -- Returner kun det siste vedtaket for denne personen
             FETCH FIRST 1 ROW ONLY
         """.trimIndent()
+
     }
 
 }

--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/SakRepository.kt
@@ -204,14 +204,14 @@ class SakRepository(private val dataSource: DataSource) {
                         AND v.rettighetkode = 'AAP'
                         AND v.utfallkode = 'JA'
                         AND v.vedtakstatuskode IN ('IVERK','AVSLU')
+                        -- krev til_dato, utenom for stansede vedtak som ikke er erstattet av et nytt vedtak
+                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode='S' AND v.vedtak_id_relatert is NULL)) 
                         -- ignorer ugyldiggjorte vedtak og etterregistrerte vedtak:
                         AND v.fra_dato IS NOT NULL
-                        -- stansvedtak kan ha null til_dato:
-                        AND (v.til_dato IS NOT NULL OR (v.vedtaktypekode='S' AND v.vedtak_id_relatert is NULL)) 
                         AND NOT ((v.fra_dato IS NOT NULL and v.til_dato IS NOT NULL) AND v.fra_dato > v.til_dato) 
                 ) WHERE rn = 1
             )
-            -- legg på informasjon om saken
+            -- Legg på informasjon om saken
             SELECT nv.sak_id, s.reg_dato as sak_registrert_dato, s.dato_avsluttet as sak_avsluttet_dato, s.sakstatuskode as sak_statuskode, 
                 s.aar, s.lopenrsak, nv.vedtak_id, nv.aktfasekode, nv.vedtaktypekode, nv.fra_dato, nv.til_dato,  
                 vmd.max_dato, vmd.max_unntak_dato
@@ -219,7 +219,8 @@ class SakRepository(private val dataSource: DataSource) {
                 JOIN v_vedtak_maxdato vmd ON vmd.vedtak_id = nv.vedtak_id
                 JOIN sak s on s.sak_id = nv.sak_id
             ORDER BY nv.til_dato DESC
-            FETCH FIRST 1 ROW ONLY -- bare det siste vedtaket
+            -- Returner kun det siste vedtaket for denne personen
+            FETCH FIRST 1 ROW ONLY
         """.trimIndent()
     }
 


### PR DESCRIPTION
Spørringen mot Arena tok ikke hensyn til at stansede vedtak vil ha null til_dato og derfor komme til sist i sorteringen som brukes, og derfor aldri bli valgt som "siste vedtak". Konsekvensen er at vi ofte ikke oppdager når det siste vedtaket i saken til en bestemt bruker er et stans-vedtak. 

Endringen sier at vi 
A åpner for at siste vedtak kan ha null til_dato, som er tilfellet for Stans-vedtak,
B men krever at det vedtaket ikke er erstattet av et annet (relatert_vedtak_id er null). 
C Dersom vi har flere stansede vedtak med null til_dato velges det med høyest år, deretter høyest løpenummer, som det siste vedtaket. 

[AAPM-204](https://nav.atlassian.net/browse/AAPM-204)