### PR TITLE
AAP-BAU Ugydliggjorte vedtak skal ikke filtreres bort

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/arenaoppslag/database/VedtakRepository.kt
@@ -131,7 +131,6 @@ class VedtakRepository(private val dataSource: DataSource) {
           LEFT JOIN aktivitetfase a ON a.aktfasekode = v.aktfasekode
           LEFT JOIN rettighettype rt ON rt.rettighetkode = v.rettighetkode
          WHERE sak_id = ?
-           AND (fra_dato <= til_dato OR til_dato IS NULL)
         """.trimIndent()
 
         private fun selectVedtakForSak(sakId: SakId, connection: Connection): List<ArenaVedtakRad> {


### PR DESCRIPTION
I endepunktet som henter detaljert informasjon om en arenasak, så bruker vi funksjonen "hentVedtakForSak", spørringen som brukes av denne filtrerte borte alle ugyldiggjorte vedtak, og dermed ble de ikke med i responsen.

Dette detaljert-endepunktet brukes av visningsklienten, så ugyldiggjorte vedtak kan være meget relevante for saksbehandler. De må derfor ikke filtreres bort.