### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/.nais/app.yml
+++ b/.nais/app.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: aap
     komponent: datadeling
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
 spec:
   image: {{image}}
   azure:

--- a/.nais/app.yml
+++ b/.nais/app.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     komponent: datadeling
+    systemkatalog.nav.no/system: TE-496
 spec:
   image: {{image}}
   azure:


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.